### PR TITLE
Expand README with run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # kittycat
-Just test
+
+Test Kotlin sandbox.
+
+## Run
+
+```
+kotlinc src/Main.kt -include-runtime -d kittycat.jar
+java -jar kittycat.jar 10
+```
+
+First arg = how many Fibonacci numbers to print (default 10).


### PR DESCRIPTION
Replace one-line README with build/run snippet.