### PR TITLE
Scaffold kitty-dashboard (multi-language)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+out/
+target/
+__pycache__/
+*.pyc
+node_modules/
+.idea/
+*.iml

--- a/config/dashboard.yaml
+++ b/config/dashboard.yaml
@@ -1,0 +1,19 @@
+server:
+  host: 0.0.0.0
+  port: 8765
+
+cache:
+  ttl_seconds: 30
+  max_entries: 1024
+
+database:
+  url: postgres://kitty:kitty@localhost:5432/kittydb
+  pool_size: 8
+
+features:
+  enable_charts: true
+  enable_history: false
+
+logging:
+  level: info
+  format: json

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,0 +1,31 @@
+# kitty-dashboard
+
+End-to-end sketch of the multi-language dashboard demo.
+
+## Components
+
+- `python/dashboard/` — backend HTTP server, aggregator, models
+- `java/src/main/java/com/kittycat/dashboard/` — JVM client with caching
+- `src/Dashboard.kt` — shared aggregation in Kotlin
+- `web/dashboard/` — vanilla HTML/CSS/JS frontend
+- `scripts/` — build pipeline and seed SQL
+- `config/dashboard.yaml` — runtime config
+
+## Data flow
+
+```
+[kitty_event SQL] -> [python aggregator] -> [/stats HTTP] -> [JS dashboard]
+                                            \-> [Java StatsClient (cached)]
+```
+
+## Local dev
+
+```
+bash scripts/build.sh
+python3 -m python.dashboard.server
+open web/dashboard/index.html
+```
+
+## Status
+
+This PR scaffolds the structure. Real persistence, auth, and CI wiring land in follow-ups.

--- a/java/src/main/java/com/kittycat/dashboard/Cache.java
+++ b/java/src/main/java/com/kittycat/dashboard/Cache.java
@@ -1,0 +1,42 @@
+package com.kittycat.dashboard;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public final class Cache {
+    private static final class Entry {
+        final String value;
+        final Instant expiresAt;
+        Entry(String value, Instant expiresAt) {
+            this.value = value;
+            this.expiresAt = expiresAt;
+        }
+    }
+
+    private final Map<String, Entry> data = new ConcurrentHashMap<>();
+    private final Duration ttl;
+
+    public Cache(Duration ttl) {
+        this.ttl = ttl;
+    }
+
+    public String get(String key) {
+        Entry e = data.get(key);
+        if (e == null) return null;
+        if (Instant.now().isAfter(e.expiresAt)) {
+            data.remove(key);
+            return null;
+        }
+        return e.value;
+    }
+
+    public void put(String key, String value) {
+        data.put(key, new Entry(value, Instant.now().plus(ttl)));
+    }
+
+    public int size() {
+        return data.size();
+    }
+}

--- a/java/src/main/java/com/kittycat/dashboard/DashboardConfig.java
+++ b/java/src/main/java/com/kittycat/dashboard/DashboardConfig.java
@@ -1,0 +1,20 @@
+package com.kittycat.dashboard;
+
+import java.net.URI;
+import java.time.Duration;
+
+public final class DashboardConfig {
+    public final URI backend;
+    public final Duration cacheTtl;
+    public final int port;
+
+    public DashboardConfig(URI backend, Duration cacheTtl, int port) {
+        this.backend = backend;
+        this.cacheTtl = cacheTtl;
+        this.port = port;
+    }
+
+    public static DashboardConfig defaults() {
+        return new DashboardConfig(URI.create("http://127.0.0.1:8765"), Duration.ofSeconds(30), 8080);
+    }
+}

--- a/java/src/main/java/com/kittycat/dashboard/StatsClient.java
+++ b/java/src/main/java/com/kittycat/dashboard/StatsClient.java
@@ -1,0 +1,35 @@
+package com.kittycat.dashboard;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+public final class StatsClient {
+    private final URI base;
+    private final HttpClient http;
+    private final Cache cache;
+
+    public StatsClient(URI base, Cache cache) {
+        this.base = base;
+        this.cache = cache;
+        this.http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+    }
+
+    public String fetchStats() throws Exception {
+        String cached = cache.get("stats");
+        if (cached != null) return cached;
+
+        HttpRequest req = HttpRequest.newBuilder(base.resolve("/stats"))
+            .timeout(Duration.ofSeconds(5))
+            .GET()
+            .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        if (resp.statusCode() != 200) {
+            throw new RuntimeException("dashboard /stats returned " + resp.statusCode());
+        }
+        cache.put("stats", resp.body());
+        return resp.body();
+    }
+}

--- a/python/dashboard/__init__.py
+++ b/python/dashboard/__init__.py
@@ -1,0 +1,5 @@
+"""kitty-dashboard backend package."""
+from .models import KittyEvent, KittyStats
+from .aggregator import aggregate
+
+__all__ = ["KittyEvent", "KittyStats", "aggregate"]

--- a/python/dashboard/aggregator.py
+++ b/python/dashboard/aggregator.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from collections import defaultdict
+from typing import Iterable, Dict
+
+from .models import KittyEvent, KittyStats
+
+
+def aggregate(events: Iterable[KittyEvent]) -> Dict[str, KittyStats]:
+    buckets: Dict[str, KittyStats] = {}
+    weight_sums: Dict[str, int] = defaultdict(int)
+    counts: Dict[str, int] = defaultdict(int)
+
+    for ev in events:
+        s = buckets.setdefault(ev.cat_id, KittyStats(cat_id=ev.cat_id))
+        s.total_events += 1
+        weight_sums[ev.cat_id] += ev.weight_g
+        counts[ev.cat_id] += 1
+        if s.last_seen is None or ev.at > s.last_seen:
+            s.last_seen = ev.at
+        if ev.kind not in s.kinds:
+            s.kinds.append(ev.kind)
+
+    for cat_id, s in buckets.items():
+        s.avg_weight_g = weight_sums[cat_id] / counts[cat_id]
+    return buckets

--- a/python/dashboard/models.py
+++ b/python/dashboard/models.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class KittyEvent:
+    cat_id: str
+    kind: str
+    weight_g: int
+    at: datetime
+
+
+@dataclass
+class KittyStats:
+    cat_id: str
+    total_events: int = 0
+    avg_weight_g: float = 0.0
+    last_seen: datetime | None = None
+    kinds: List[str] = field(default_factory=list)

--- a/python/dashboard/server.py
+++ b/python/dashboard/server.py
@@ -1,0 +1,39 @@
+"""Tiny Flask-style HTTP server stub for the kitty dashboard."""
+from __future__ import annotations
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Dict, List
+
+from .aggregator import aggregate
+from .models import KittyEvent
+
+EVENTS: List[KittyEvent] = []
+
+
+class DashboardHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        if self.path == "/healthz":
+            self._json(200, {"ok": True})
+            return
+        if self.path == "/stats":
+            stats = aggregate(EVENTS)
+            payload = {cid: s.__dict__ for cid, s in stats.items()}
+            self._json(200, payload)
+            return
+        self._json(404, {"error": "not found"})
+
+    def _json(self, code: int, body: Dict) -> None:
+        data = json.dumps(body, default=str).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def serve(host: str = "127.0.0.1", port: int = 8765) -> None:
+    HTTPServer((host, port), DashboardHandler).serve_forever()
+
+
+if __name__ == "__main__":
+    serve()

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "[build] Kotlin"
+kotlinc "$ROOT/src/Main.kt" "$ROOT/src/Dashboard.kt" -include-runtime -d "$ROOT/out/kittycat.jar"
+
+echo "[build] Java"
+(cd "$ROOT/java" && mvn -q -DskipTests package)
+
+echo "[build] Python (lint only)"
+python3 -m compileall -q "$ROOT/python"
+
+echo "[build] done"

--- a/scripts/seed_data.sql
+++ b/scripts/seed_data.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS kitty_event (
+    id           BIGSERIAL PRIMARY KEY,
+    cat_id       TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    weight_g     INTEGER NOT NULL,
+    occurred_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kitty_event_cat_time
+    ON kitty_event (cat_id, occurred_at DESC);
+
+INSERT INTO kitty_event (cat_id, kind, weight_g, occurred_at) VALUES
+    ('luna',  'nap',  4200, now() - interval '2 hours'),
+    ('luna',  'play', 4180, now() - interval '90 minutes'),
+    ('mochi', 'nap',  3300, now() - interval '4 hours'),
+    ('mochi', 'snack',3320, now() - interval '30 minutes'),
+    ('pixel', 'play', 5100, now() - interval '10 minutes');

--- a/src/Dashboard.kt
+++ b/src/Dashboard.kt
@@ -1,0 +1,27 @@
+package com.kittycat.dashboard
+
+data class KittyEvent(
+    val catId: String,
+    val kind: String,
+    val weightG: Int,
+    val atMillis: Long
+)
+
+data class KittyStats(
+    val catId: String,
+    val totalEvents: Int,
+    val avgWeightG: Double,
+    val lastSeenMillis: Long,
+    val kinds: List<String>
+)
+
+object Dashboard {
+    fun aggregate(events: List<KittyEvent>): Map<String, KittyStats> {
+        return events.groupBy { it.catId }.mapValues { (catId, group) ->
+            val avg = group.sumOf { it.weightG }.toDouble() / group.size
+            val last = group.maxOf { it.atMillis }
+            val kinds = group.map { it.kind }.distinct()
+            KittyStats(catId, group.size, avg, last, kinds)
+        }
+    }
+}

--- a/tests/python/test_aggregator.py
+++ b/tests/python/test_aggregator.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timedelta
+
+import pytest
+
+from python.dashboard.aggregator import aggregate
+from python.dashboard.models import KittyEvent
+
+
+def _ev(cat: str, kind: str, w: int, offset_min: int = 0) -> KittyEvent:
+    return KittyEvent(cat_id=cat, kind=kind, weight_g=w, at=datetime(2026, 1, 1) + timedelta(minutes=offset_min))
+
+
+def test_aggregate_groups_by_cat() -> None:
+    out = aggregate([_ev("a", "nap", 3200), _ev("b", "nap", 4100), _ev("a", "play", 3210, 5)])
+    assert set(out) == {"a", "b"}
+    assert out["a"].total_events == 2
+    assert out["b"].total_events == 1
+
+
+def test_aggregate_avg_weight() -> None:
+    out = aggregate([_ev("a", "x", 100), _ev("a", "x", 200), _ev("a", "x", 300)])
+    assert out["a"].avg_weight_g == pytest.approx(200.0)
+
+
+def test_aggregate_tracks_kinds_in_order() -> None:
+    out = aggregate([_ev("a", "nap", 1), _ev("a", "play", 1), _ev("a", "nap", 1)])
+    assert out["a"].kinds == ["nap", "play"]
+
+
+def test_aggregate_empty() -> None:
+    assert aggregate([]) == {}

--- a/web/dashboard/components/chart.js
+++ b/web/dashboard/components/chart.js
@@ -1,0 +1,22 @@
+export function renderChart(canvas, stats) {
+  const ctx = canvas.getContext("2d");
+  const entries = Object.entries(stats);
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  if (entries.length === 0) {
+    ctx.fillStyle = "#888";
+    ctx.fillText("no data", 20, 20);
+    return;
+  }
+
+  const max = Math.max(...entries.map(([, s]) => s.avg_weight_g));
+  const barW = canvas.width / entries.length;
+
+  entries.forEach(([catId, s], i) => {
+    const h = (s.avg_weight_g / max) * (canvas.height - 40);
+    ctx.fillStyle = "#d96c4a";
+    ctx.fillRect(i * barW + 8, canvas.height - h - 20, barW - 16, h);
+    ctx.fillStyle = "#1f1f1f";
+    ctx.fillText(catId, i * barW + 12, canvas.height - 4);
+  });
+}

--- a/web/dashboard/dashboard.css
+++ b/web/dashboard/dashboard.css
@@ -1,0 +1,53 @@
+:root {
+  --bg: #faf7f2;
+  --fg: #1f1f1f;
+  --accent: #d96c4a;
+  --card-bg: #fff;
+  --border: #eadfd2;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.topbar h1 { margin: 0; font-size: 1.4rem; color: var(--accent); }
+
+#refresh {
+  background: var(--accent);
+  color: #fff;
+  border: 0;
+  border-radius: 999px;
+  padding: 0.4rem 1rem;
+  cursor: pointer;
+}
+
+main { padding: 1.5rem; }
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.cards article {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+canvas { background: var(--card-bg); border: 1px solid var(--border); border-radius: 12px; }

--- a/web/dashboard/dashboard.js
+++ b/web/dashboard/dashboard.js
@@ -1,0 +1,37 @@
+import { renderChart } from "./components/chart.js";
+
+const STATS_URL = "/stats";
+
+async function loadStats() {
+  const res = await fetch(STATS_URL);
+  if (!res.ok) throw new Error(`stats ${res.status}`);
+  return res.json();
+}
+
+function renderCards(stats) {
+  const root = document.getElementById("cards");
+  root.innerHTML = "";
+  for (const [catId, s] of Object.entries(stats)) {
+    const card = document.createElement("article");
+    card.innerHTML = `
+      <h2>${catId}</h2>
+      <p>Events: ${s.total_events}</p>
+      <p>Avg weight: ${Math.round(s.avg_weight_g)} g</p>
+      <p>Kinds: ${s.kinds.join(", ")}</p>
+    `;
+    root.appendChild(card);
+  }
+}
+
+async function refresh() {
+  try {
+    const stats = await loadStats();
+    renderCards(stats);
+    renderChart(document.getElementById("weight-chart"), stats);
+  } catch (err) {
+    console.error("refresh failed", err);
+  }
+}
+
+document.getElementById("refresh").addEventListener("click", refresh);
+refresh();

--- a/web/dashboard/index.html
+++ b/web/dashboard/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kitty-dashboard</title>
+  <link rel="stylesheet" href="dashboard.css">
+  <script type="module" src="dashboard.js" defer></script>
+</head>
+<body>
+  <header class="topbar">
+    <h1>kitty-dashboard</h1>
+    <button id="refresh">Refresh</button>
+  </header>
+  <main>
+    <section id="cards" class="cards"></section>
+    <canvas id="weight-chart" width="640" height="240"></canvas>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Scaffolds the kitty-dashboard demo across the repo.

## Files

**Python backend** — `python/dashboard/`
- `models.py` — KittyEvent / KittyStats dataclasses
- `aggregator.py` — per-cat aggregation
- `server.py` — stdlib HTTPServer with /stats and /healthz

**Java client** — `java/src/main/java/com/kittycat/dashboard/`
- `StatsClient.java` — HTTP client with TTL cache
- `Cache.java` — concurrent TTL cache
- `DashboardConfig.java` — config holder

**Kotlin** — `src/Dashboard.kt` — shared aggregation in Kotlin

**Web** — `web/dashboard/`
- `index.html` + `dashboard.css` + `dashboard.js` + `components/chart.js`

**Other**
- `tests/python/test_aggregator.py` — pytest cases
- `scripts/build.sh` — multi-language build driver
- `scripts/seed_data.sql` — Postgres schema + sample rows
- `config/dashboard.yaml`
- `docs/dashboard.md`
- `.gitignore`

## Status

Scaffold only — does not necessarily compile/run end-to-end. Follow-ups will wire persistence, auth, and CI.