### PR TITLE
Add go-kitty user registry service

### DIFF
--- a/go-kitty/README.md
+++ b/go-kitty/README.md
@@ -1,0 +1,30 @@
+# go-kitty
+
+Small Go service exposing a user registry over HTTP.
+
+## Layout
+
+```
+go-kitty/
+├── cmd/kittyapi/      # main entrypoint
+└── internal/
+    ├── users/         # domain: User, Service, Repository
+    ├── httpapi/       # HTTP server + middleware
+    ├── token/         # crypto/rand-backed IDs and API keys
+    ├── db/            # parameterized SQL queries
+    └── concurrency/   # errgroup-based fan-out helper
+```
+
+## Run
+
+```
+cd go-kitty
+go run ./cmd/kittyapi
+```
+
+## Test
+
+```
+cd go-kitty
+go test ./...
+```

--- a/go-kitty/cmd/kittyapi/main.go
+++ b/go-kitty/cmd/kittyapi/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-kitty/internal/httpapi"
+	"github.com/Andrey-Test-Org/kittycat/go-kitty/internal/users"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	svc := users.NewService(users.NewInMemoryRepository(), logger)
+	srv := httpapi.NewServer(":8080", svc, logger)
+
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server exited unexpectedly", "err", err)
+			os.Exit(1)
+		}
+	}()
+	logger.Info("kittyapi started", "addr", srv.Addr)
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("graceful shutdown failed", "err", err)
+		os.Exit(1)
+	}
+	logger.Info("kittyapi stopped")
+}

--- a/go-kitty/cmd/kittyapi/main.go
+++ b/go-kitty/cmd/kittyapi/main.go
@@ -21,7 +21,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	svc := users.NewService(users.NewInMemoryRepository(), logger)
+	svc := users.NewService(users.NewInMemoryRepository())
 	srv := httpapi.NewServer(":8080", svc, logger)
 
 	go func() {

--- a/go-kitty/go.mod
+++ b/go-kitty/go.mod
@@ -1,0 +1,5 @@
+module github.com/Andrey-Test-Org/kittycat/go-kitty
+
+go 1.22
+
+require golang.org/x/sync v0.7.0

--- a/go-kitty/internal/concurrency/fanout.go
+++ b/go-kitty/internal/concurrency/fanout.go
@@ -1,3 +1,5 @@
+// Package concurrency contains small, reusable helpers for running work
+// across goroutines with first-error semantics via errgroup.
 package concurrency
 
 import (
@@ -7,8 +9,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Task is a unit of asynchronous work returning a typed value and an error.
 type Task[T any] func(ctx context.Context) (T, error)
 
+// Fanout runs all tasks concurrently and returns their results in the same
+// order as the input. The first task error cancels the shared context and
+// causes Fanout to return that error, wrapped with the failing task index.
 func Fanout[T any](ctx context.Context, tasks []Task[T]) ([]T, error) {
 	results := make([]T, len(tasks))
 

--- a/go-kitty/internal/concurrency/fanout.go
+++ b/go-kitty/internal/concurrency/fanout.go
@@ -1,0 +1,32 @@
+package concurrency
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
+
+type Task[T any] func(ctx context.Context) (T, error)
+
+func Fanout[T any](ctx context.Context, tasks []Task[T]) ([]T, error) {
+	results := make([]T, len(tasks))
+
+	g, gctx := errgroup.WithContext(ctx)
+	for i, task := range tasks {
+		i, task := i, task
+		g.Go(func() error {
+			value, err := task(gctx)
+			if err != nil {
+				return fmt.Errorf("task %d: %w", i, err)
+			}
+			results[i] = value
+			return nil
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("fanout: %w", err)
+	}
+	return results, nil
+}

--- a/go-kitty/internal/concurrency/fanout_test.go
+++ b/go-kitty/internal/concurrency/fanout_test.go
@@ -1,0 +1,59 @@
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestFanout(t *testing.T) {
+	sentinel := errors.New("boom")
+
+	tests := []struct {
+		name    string
+		tasks   []Task[int]
+		want    []int
+		wantErr error
+	}{
+		{
+			name: "all succeed",
+			tasks: []Task[int]{
+				func(context.Context) (int, error) { return 1, nil },
+				func(context.Context) (int, error) { return 2, nil },
+				func(context.Context) (int, error) { return 3, nil },
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "one fails",
+			tasks: []Task[int]{
+				func(context.Context) (int, error) { return 1, nil },
+				func(context.Context) (int, error) { return 0, sentinel },
+			},
+			wantErr: sentinel,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Fanout(context.Background(), tc.tasks)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("Fanout: want %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Fanout: unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("Fanout result length: want %d, got %d", len(tc.want), len(got))
+			}
+			for i, v := range tc.want {
+				if got[i] != v {
+					t.Errorf("Fanout[%d]: want %d, got %d", i, v, got[i])
+				}
+			}
+		})
+	}
+}

--- a/go-kitty/internal/concurrency/fanout_test.go
+++ b/go-kitty/internal/concurrency/fanout_test.go
@@ -7,6 +7,8 @@ import (
 )
 
 func TestFanout(t *testing.T) {
+	t.Parallel()
+
 	sentinel := errors.New("boom")
 
 	tests := []struct {
@@ -35,7 +37,9 @@ func TestFanout(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			got, err := Fanout(context.Background(), tc.tasks)
 			if tc.wantErr != nil {
 				if !errors.Is(err, tc.wantErr) {

--- a/go-kitty/internal/db/queries.go
+++ b/go-kitty/internal/db/queries.go
@@ -1,3 +1,4 @@
+// Package db contains parameterized SQL queries against the users schema.
 package db
 
 import (
@@ -6,6 +7,7 @@ import (
 	"fmt"
 )
 
+// UserRow is a minimal projection of the users table.
 type UserRow struct {
 	ID    string
 	Email string
@@ -17,14 +19,17 @@ const (
 	queryListByDomain = `SELECT id, email FROM users WHERE email LIKE $1 ORDER BY created_at DESC LIMIT $2`
 )
 
+// Queries provides typed access to the users-table SQL queries.
 type Queries struct {
 	conn *sql.DB
 }
 
+// NewQueries wraps the given *sql.DB. The caller retains ownership of conn.
 func NewQueries(conn *sql.DB) *Queries {
 	return &Queries{conn: conn}
 }
 
+// GetUserByID returns the row for the given id, or a wrapped sql.ErrNoRows if absent.
 func (q *Queries) GetUserByID(ctx context.Context, id string) (UserRow, error) {
 	var u UserRow
 	if err := q.conn.QueryRowContext(ctx, queryGetUserByID, id).Scan(&u.ID, &u.Email); err != nil {
@@ -33,6 +38,7 @@ func (q *Queries) GetUserByID(ctx context.Context, id string) (UserRow, error) {
 	return u, nil
 }
 
+// InsertUser inserts a new row into the users table.
 func (q *Queries) InsertUser(ctx context.Context, id, email, apiKey string) error {
 	if _, err := q.conn.ExecContext(ctx, queryInsertUser, id, email, apiKey); err != nil {
 		return fmt.Errorf("insert user %s: %w", id, err)
@@ -40,6 +46,8 @@ func (q *Queries) InsertUser(ctx context.Context, id, email, apiKey string) erro
 	return nil
 }
 
+// ListByEmailDomain returns up to limit rows whose email ends with @domain,
+// ordered by created_at descending.
 func (q *Queries) ListByEmailDomain(ctx context.Context, domain string, limit int) ([]UserRow, error) {
 	rows, err := q.conn.QueryContext(ctx, queryListByDomain, "%@"+domain, limit)
 	if err != nil {

--- a/go-kitty/internal/db/queries.go
+++ b/go-kitty/internal/db/queries.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type UserRow struct {
+	ID    string
+	Email string
+}
+
+const (
+	queryGetUserByID  = `SELECT id, email FROM users WHERE id = $1`
+	queryInsertUser   = `INSERT INTO users (id, email, api_key) VALUES ($1, $2, $3)`
+	queryListByDomain = `SELECT id, email FROM users WHERE email LIKE $1 ORDER BY created_at DESC LIMIT $2`
+)
+
+type Queries struct {
+	conn *sql.DB
+}
+
+func NewQueries(conn *sql.DB) *Queries {
+	return &Queries{conn: conn}
+}
+
+func (q *Queries) GetUserByID(ctx context.Context, id string) (UserRow, error) {
+	var u UserRow
+	if err := q.conn.QueryRowContext(ctx, queryGetUserByID, id).Scan(&u.ID, &u.Email); err != nil {
+		return UserRow{}, fmt.Errorf("get user %s: %w", id, err)
+	}
+	return u, nil
+}
+
+func (q *Queries) InsertUser(ctx context.Context, id, email, apiKey string) error {
+	if _, err := q.conn.ExecContext(ctx, queryInsertUser, id, email, apiKey); err != nil {
+		return fmt.Errorf("insert user %s: %w", id, err)
+	}
+	return nil
+}
+
+func (q *Queries) ListByEmailDomain(ctx context.Context, domain string, limit int) ([]UserRow, error) {
+	rows, err := q.conn.QueryContext(ctx, queryListByDomain, "%@"+domain, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list users by domain %s: %w", domain, err)
+	}
+	defer rows.Close()
+
+	out := make([]UserRow, 0, limit)
+	for rows.Next() {
+		var u UserRow
+		if err := rows.Scan(&u.ID, &u.Email); err != nil {
+			return nil, fmt.Errorf("scan user row: %w", err)
+		}
+		out = append(out, u)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user rows: %w", err)
+	}
+	return out, nil
+}

--- a/go-kitty/internal/httpapi/middleware.go
+++ b/go-kitty/internal/httpapi/middleware.go
@@ -1,0 +1,31 @@
+package httpapi
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+func WithRequestLogging(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sw, r)
+		logger.Info("http request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", sw.status,
+			"durationMS", time.Since(start).Milliseconds(),
+		)
+	})
+}
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusWriter) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}

--- a/go-kitty/internal/httpapi/middleware.go
+++ b/go-kitty/internal/httpapi/middleware.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+// WithRequestLogging wraps next so each handled request emits a single
+// structured log line with method, path, response status, and duration.
 func WithRequestLogging(logger *slog.Logger, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()

--- a/go-kitty/internal/httpapi/server.go
+++ b/go-kitty/internal/httpapi/server.go
@@ -1,9 +1,11 @@
+// Package httpapi exposes the user Service over HTTP.
 package httpapi
 
 import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"time"
@@ -11,12 +13,19 @@ import (
 	"github.com/Andrey-Test-Org/kittycat/go-kitty/internal/users"
 )
 
+// maxBodyBytes caps incoming JSON request bodies.
+const maxBodyBytes = 1 << 20 // 1 MiB
+
+// Server is the HTTP transport for the user Service.
 type Server struct {
 	*http.Server
 	svc    *users.Service
 	logger *slog.Logger
 }
 
+// NewServer builds an HTTP server bound to addr. The logger is used by the
+// transport layer (request log, response encode errors) only; the user
+// Service itself never logs.
 func NewServer(addr string, svc *users.Service, logger *slog.Logger) *Server {
 	s := &Server{svc: svc, logger: logger}
 	mux := http.NewServeMux()
@@ -37,11 +46,20 @@ type registerRequest struct {
 }
 
 func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
 	var req registerRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := dec.Decode(&req); err != nil {
 		s.writeError(w, http.StatusBadRequest, fmt.Errorf("decode register: %w", err))
 		return
 	}
+	if extra := dec.Decode(&struct{}{}); !errors.Is(extra, io.EOF) {
+		s.writeError(w, http.StatusBadRequest, errors.New("request body must contain a single JSON object"))
+		return
+	}
+
 	u, err := s.svc.Register(r.Context(), req.Email)
 	if err != nil {
 		switch {
@@ -54,6 +72,8 @@ func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
 		}
 		return
 	}
+	// Transport-layer logging (not library logging): log non-PII identifiers only.
+	s.logger.Info("user registered", "userID", u.ID)
 	s.writeJSON(w, http.StatusCreated, u)
 }
 
@@ -61,11 +81,14 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
 	u, err := s.svc.Get(r.Context(), id)
 	if err != nil {
-		if errors.Is(err, users.ErrNotFound) {
+		switch {
+		case errors.Is(err, users.ErrInvalidID):
+			s.writeError(w, http.StatusBadRequest, err)
+		case errors.Is(err, users.ErrNotFound):
 			s.writeError(w, http.StatusNotFound, err)
-			return
+		default:
+			s.writeError(w, http.StatusInternalServerError, err)
 		}
-		s.writeError(w, http.StatusInternalServerError, err)
 		return
 	}
 	s.writeJSON(w, http.StatusOK, u)

--- a/go-kitty/internal/httpapi/server.go
+++ b/go-kitty/internal/httpapi/server.go
@@ -1,0 +1,94 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-kitty/internal/users"
+)
+
+type Server struct {
+	*http.Server
+	svc    *users.Service
+	logger *slog.Logger
+}
+
+func NewServer(addr string, svc *users.Service, logger *slog.Logger) *Server {
+	s := &Server{svc: svc, logger: logger}
+	mux := http.NewServeMux()
+	mux.HandleFunc("POST /users", s.handleRegister)
+	mux.HandleFunc("GET /users/{id}", s.handleGet)
+	mux.HandleFunc("GET /users", s.handleList)
+
+	s.Server = &http.Server{
+		Addr:              addr,
+		Handler:           WithRequestLogging(logger, mux),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return s
+}
+
+type registerRequest struct {
+	Email string `json:"email"`
+}
+
+func (s *Server) handleRegister(w http.ResponseWriter, r *http.Request) {
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		s.writeError(w, http.StatusBadRequest, fmt.Errorf("decode register: %w", err))
+		return
+	}
+	u, err := s.svc.Register(r.Context(), req.Email)
+	if err != nil {
+		switch {
+		case errors.Is(err, users.ErrInvalidEmail):
+			s.writeError(w, http.StatusBadRequest, err)
+		case errors.Is(err, users.ErrAlreadyExists):
+			s.writeError(w, http.StatusConflict, err)
+		default:
+			s.writeError(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+	s.writeJSON(w, http.StatusCreated, u)
+}
+
+func (s *Server) handleGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	u, err := s.svc.Get(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, users.ErrNotFound) {
+			s.writeError(w, http.StatusNotFound, err)
+			return
+		}
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, u)
+}
+
+func (s *Server) handleList(w http.ResponseWriter, r *http.Request) {
+	all, err := s.svc.List(r.Context())
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+	s.writeJSON(w, http.StatusOK, all)
+}
+
+func (s *Server) writeJSON(w http.ResponseWriter, code int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		s.logger.Error("encode response", "err", err)
+	}
+}
+
+func (s *Server) writeError(w http.ResponseWriter, code int, err error) {
+	s.logger.Warn("request failed", "status", code, "err", err)
+	s.writeJSON(w, code, map[string]string{"error": err.Error()})
+}

--- a/go-kitty/internal/token/generator.go
+++ b/go-kitty/internal/token/generator.go
@@ -1,3 +1,4 @@
+// Package token issues cryptographically random identifiers and API keys.
 package token
 
 import (
@@ -11,6 +12,7 @@ const (
 	idBytes     = 12
 )
 
+// NewAPIKey returns a hex-encoded 32-byte random API key sourced from crypto/rand.
 func NewAPIKey() (string, error) {
 	buf := make([]byte, apiKeyBytes)
 	if _, err := rand.Read(buf); err != nil {
@@ -19,10 +21,12 @@ func NewAPIKey() (string, error) {
 	return hex.EncodeToString(buf), nil
 }
 
-func NewID() string {
+// NewID returns a hex-encoded 12-byte random identifier sourced from crypto/rand.
+// Returns an error if the system entropy source is unavailable.
+func NewID() (string, error) {
 	buf := make([]byte, idBytes)
 	if _, err := rand.Read(buf); err != nil {
-		panic(fmt.Errorf("crypto/rand unavailable: %w", err))
+		return "", fmt.Errorf("read crypto/rand: %w", err)
 	}
-	return hex.EncodeToString(buf)
+	return hex.EncodeToString(buf), nil
 }

--- a/go-kitty/internal/token/generator.go
+++ b/go-kitty/internal/token/generator.go
@@ -1,0 +1,28 @@
+package token
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	apiKeyBytes = 32
+	idBytes     = 12
+)
+
+func NewAPIKey() (string, error) {
+	buf := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("read crypto/rand: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func NewID() string {
+	buf := make([]byte, idBytes)
+	if _, err := rand.Read(buf); err != nil {
+		panic(fmt.Errorf("crypto/rand unavailable: %w", err))
+	}
+	return hex.EncodeToString(buf)
+}

--- a/go-kitty/internal/token/generator_test.go
+++ b/go-kitty/internal/token/generator_test.go
@@ -3,6 +3,8 @@ package token
 import "testing"
 
 func TestNewAPIKey(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		want int
@@ -11,7 +13,9 @@ func TestNewAPIKey(t *testing.T) {
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			key, err := NewAPIKey()
 			if err != nil {
 				t.Fatalf("NewAPIKey: %v", err)
@@ -24,6 +28,8 @@ func TestNewAPIKey(t *testing.T) {
 }
 
 func TestNewAPIKey_Unique(t *testing.T) {
+	t.Parallel()
+
 	seen := make(map[string]struct{}, 100)
 	for i := 0; i < 100; i++ {
 		key, err := NewAPIKey()
@@ -34,5 +40,17 @@ func TestNewAPIKey_Unique(t *testing.T) {
 			t.Fatalf("duplicate API key after %d iterations: %s", i, key)
 		}
 		seen[key] = struct{}{}
+	}
+}
+
+func TestNewID(t *testing.T) {
+	t.Parallel()
+
+	id, err := NewID()
+	if err != nil {
+		t.Fatalf("NewID: %v", err)
+	}
+	if len(id) != 24 {
+		t.Fatalf("NewID length: want 24, got %d", len(id))
 	}
 }

--- a/go-kitty/internal/token/generator_test.go
+++ b/go-kitty/internal/token/generator_test.go
@@ -1,0 +1,38 @@
+package token
+
+import "testing"
+
+func TestNewAPIKey(t *testing.T) {
+	tests := []struct {
+		name string
+		want int
+	}{
+		{name: "length is 64 hex chars (32 bytes)", want: 64},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			key, err := NewAPIKey()
+			if err != nil {
+				t.Fatalf("NewAPIKey: %v", err)
+			}
+			if len(key) != tc.want {
+				t.Fatalf("NewAPIKey length: want %d, got %d", tc.want, len(key))
+			}
+		})
+	}
+}
+
+func TestNewAPIKey_Unique(t *testing.T) {
+	seen := make(map[string]struct{}, 100)
+	for i := 0; i < 100; i++ {
+		key, err := NewAPIKey()
+		if err != nil {
+			t.Fatalf("NewAPIKey: %v", err)
+		}
+		if _, dup := seen[key]; dup {
+			t.Fatalf("duplicate API key after %d iterations: %s", i, key)
+		}
+		seen[key] = struct{}{}
+	}
+}

--- a/go-kitty/internal/users/errors.go
+++ b/go-kitty/internal/users/errors.go
@@ -1,0 +1,9 @@
+package users
+
+import "errors"
+
+var (
+	ErrNotFound      = errors.New("user not found")
+	ErrAlreadyExists = errors.New("user already exists")
+	ErrInvalidEmail  = errors.New("invalid email")
+)

--- a/go-kitty/internal/users/errors.go
+++ b/go-kitty/internal/users/errors.go
@@ -2,8 +2,15 @@ package users
 
 import "errors"
 
+// Sentinel errors returned by the users package. Callers should match these
+// with errors.Is to translate to transport-specific status codes.
 var (
-	ErrNotFound      = errors.New("user not found")
+	// ErrNotFound is returned when no user matches the requested identifier.
+	ErrNotFound = errors.New("user not found")
+	// ErrAlreadyExists is returned when attempting to create a user whose id is taken.
 	ErrAlreadyExists = errors.New("user already exists")
-	ErrInvalidEmail  = errors.New("invalid email")
+	// ErrInvalidEmail is returned when the supplied email fails validation.
+	ErrInvalidEmail = errors.New("invalid email")
+	// ErrInvalidID is returned when an id is empty, too long, or not lowercase hex.
+	ErrInvalidID = errors.New("invalid id")
 )

--- a/go-kitty/internal/users/repository.go
+++ b/go-kitty/internal/users/repository.go
@@ -1,0 +1,61 @@
+package users
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type Repository interface {
+	Create(ctx context.Context, u User) error
+	Get(ctx context.Context, id string) (User, error)
+	List(ctx context.Context) ([]User, error)
+}
+
+type inMemoryRepo struct {
+	mu   sync.RWMutex
+	data map[string]User
+}
+
+func NewInMemoryRepository() Repository {
+	return &inMemoryRepo{data: make(map[string]User)}
+}
+
+func (r *inMemoryRepo) Create(ctx context.Context, u User) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("create user: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.data[u.ID]; ok {
+		return fmt.Errorf("create user %s: %w", u.ID, ErrAlreadyExists)
+	}
+	r.data[u.ID] = u
+	return nil
+}
+
+func (r *inMemoryRepo) Get(ctx context.Context, id string) (User, error) {
+	if err := ctx.Err(); err != nil {
+		return User{}, fmt.Errorf("get user: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	u, ok := r.data[id]
+	if !ok {
+		return User{}, fmt.Errorf("get user %s: %w", id, ErrNotFound)
+	}
+	return u, nil
+}
+
+func (r *inMemoryRepo) List(ctx context.Context) ([]User, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]User, 0, len(r.data))
+	for _, u := range r.data {
+		out = append(out, u)
+	}
+	return out, nil
+}

--- a/go-kitty/internal/users/repository.go
+++ b/go-kitty/internal/users/repository.go
@@ -6,22 +6,28 @@ import (
 	"sync"
 )
 
+// Repository is the storage contract the user Service depends on.
+// Implementations must be safe for concurrent use.
 type Repository interface {
 	Create(ctx context.Context, u User) error
 	Get(ctx context.Context, id string) (User, error)
 	List(ctx context.Context) ([]User, error)
 }
 
-type inMemoryRepo struct {
+// InMemoryRepository is a thread-safe in-process implementation of Repository,
+// intended for tests and local development.
+type InMemoryRepository struct {
 	mu   sync.RWMutex
 	data map[string]User
 }
 
-func NewInMemoryRepository() Repository {
-	return &inMemoryRepo{data: make(map[string]User)}
+// NewInMemoryRepository returns a new InMemoryRepository ready for use.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{data: make(map[string]User)}
 }
 
-func (r *inMemoryRepo) Create(ctx context.Context, u User) error {
+// Create stores a new user. Returns ErrAlreadyExists if the id is taken.
+func (r *InMemoryRepository) Create(ctx context.Context, u User) error {
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("create user: %w", err)
 	}
@@ -34,7 +40,8 @@ func (r *inMemoryRepo) Create(ctx context.Context, u User) error {
 	return nil
 }
 
-func (r *inMemoryRepo) Get(ctx context.Context, id string) (User, error) {
+// Get returns the user with the given id. Returns ErrNotFound if absent.
+func (r *InMemoryRepository) Get(ctx context.Context, id string) (User, error) {
 	if err := ctx.Err(); err != nil {
 		return User{}, fmt.Errorf("get user: %w", err)
 	}
@@ -47,7 +54,8 @@ func (r *inMemoryRepo) Get(ctx context.Context, id string) (User, error) {
 	return u, nil
 }
 
-func (r *inMemoryRepo) List(ctx context.Context) ([]User, error) {
+// List returns all stored users in unspecified order.
+func (r *InMemoryRepository) List(ctx context.Context) ([]User, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, fmt.Errorf("list users: %w", err)
 	}

--- a/go-kitty/internal/users/service.go
+++ b/go-kitty/internal/users/service.go
@@ -3,48 +3,61 @@ package users
 import (
 	"context"
 	"fmt"
-	"log/slog"
+	"net/mail"
 	"strings"
 	"time"
 
 	"github.com/Andrey-Test-Org/kittycat/go-kitty/internal/token"
 )
 
+// maxEmailLength bounds accepted email addresses to a sane upper limit.
+const maxEmailLength = 254
+
+// Service is the application-level entry point for user operations.
+// It coordinates input validation, ID/key issuance, and persistence.
 type Service struct {
-	repo   Repository
-	logger *slog.Logger
+	repo Repository
 }
 
-func NewService(repo Repository, logger *slog.Logger) *Service {
-	return &Service{repo: repo, logger: logger}
+// NewService constructs a Service backed by the given Repository.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
 }
 
+// Register validates the provided email, mints a new ID and API key,
+// and persists the resulting user. Returns ErrInvalidEmail for invalid input.
 func (s *Service) Register(ctx context.Context, email string) (User, error) {
-	email = strings.TrimSpace(strings.ToLower(email))
-	if !strings.Contains(email, "@") {
-		return User{}, fmt.Errorf("register %q: %w", email, ErrInvalidEmail)
+	normalized, err := normalizeEmail(email)
+	if err != nil {
+		return User{}, fmt.Errorf("register: %w", err)
 	}
 
 	apiKey, err := token.NewAPIKey()
 	if err != nil {
 		return User{}, fmt.Errorf("register: generate API key: %w", err)
 	}
+	id, err := token.NewID()
+	if err != nil {
+		return User{}, fmt.Errorf("register: generate ID: %w", err)
+	}
 
 	u := User{
-		ID:        token.NewID(),
-		Email:     email,
+		ID:        id,
+		Email:     normalized,
 		APIKey:    apiKey,
 		CreatedAt: time.Now().UTC(),
 	}
 	if err := s.repo.Create(ctx, u); err != nil {
 		return User{}, fmt.Errorf("register: persist user: %w", err)
 	}
-
-	s.logger.Info("user registered", "userID", u.ID, "email", u.Email)
 	return u, nil
 }
 
+// Get returns the user with the given id, or ErrNotFound.
 func (s *Service) Get(ctx context.Context, id string) (User, error) {
+	if err := validateID(id); err != nil {
+		return User{}, fmt.Errorf("get user: %w", err)
+	}
 	u, err := s.repo.Get(ctx, id)
 	if err != nil {
 		return User{}, fmt.Errorf("get user: %w", err)
@@ -52,10 +65,39 @@ func (s *Service) Get(ctx context.Context, id string) (User, error) {
 	return u, nil
 }
 
+// List returns all stored users.
 func (s *Service) List(ctx context.Context) ([]User, error) {
 	users, err := s.repo.List(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("list users: %w", err)
 	}
 	return users, nil
+}
+
+func normalizeEmail(raw string) (string, error) {
+	trimmed := strings.TrimSpace(strings.ToLower(raw))
+	if trimmed == "" || len(trimmed) > maxEmailLength {
+		return "", ErrInvalidEmail
+	}
+	addr, err := mail.ParseAddress(trimmed)
+	if err != nil {
+		return "", ErrInvalidEmail
+	}
+	return addr.Address, nil
+}
+
+func validateID(id string) error {
+	if id == "" || len(id) > 64 {
+		return ErrInvalidID
+	}
+	for _, r := range id {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return ErrInvalidID
+		}
+	}
+	return nil
 }

--- a/go-kitty/internal/users/service.go
+++ b/go-kitty/internal/users/service.go
@@ -1,0 +1,61 @@
+package users
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-kitty/internal/token"
+)
+
+type Service struct {
+	repo   Repository
+	logger *slog.Logger
+}
+
+func NewService(repo Repository, logger *slog.Logger) *Service {
+	return &Service{repo: repo, logger: logger}
+}
+
+func (s *Service) Register(ctx context.Context, email string) (User, error) {
+	email = strings.TrimSpace(strings.ToLower(email))
+	if !strings.Contains(email, "@") {
+		return User{}, fmt.Errorf("register %q: %w", email, ErrInvalidEmail)
+	}
+
+	apiKey, err := token.NewAPIKey()
+	if err != nil {
+		return User{}, fmt.Errorf("register: generate API key: %w", err)
+	}
+
+	u := User{
+		ID:        token.NewID(),
+		Email:     email,
+		APIKey:    apiKey,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.repo.Create(ctx, u); err != nil {
+		return User{}, fmt.Errorf("register: persist user: %w", err)
+	}
+
+	s.logger.Info("user registered", "userID", u.ID, "email", u.Email)
+	return u, nil
+}
+
+func (s *Service) Get(ctx context.Context, id string) (User, error) {
+	u, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return User{}, fmt.Errorf("get user: %w", err)
+	}
+	return u, nil
+}
+
+func (s *Service) List(ctx context.Context) ([]User, error) {
+	users, err := s.repo.List(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("list users: %w", err)
+	}
+	return users, nil
+}

--- a/go-kitty/internal/users/service_test.go
+++ b/go-kitty/internal/users/service_test.go
@@ -3,17 +3,17 @@ package users
 import (
 	"context"
 	"errors"
-	"io"
-	"log/slog"
 	"testing"
 )
 
 func newTestService(t *testing.T) *Service {
 	t.Helper()
-	return NewService(NewInMemoryRepository(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return NewService(NewInMemoryRepository())
 }
 
 func TestService_Register(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		email   string
@@ -22,10 +22,13 @@ func TestService_Register(t *testing.T) {
 		{name: "valid", email: "luna@example.com", wantErr: nil},
 		{name: "missing at", email: "lunaexample.com", wantErr: ErrInvalidEmail},
 		{name: "blank", email: "   ", wantErr: ErrInvalidEmail},
+		{name: "too long", email: longEmail(), wantErr: ErrInvalidEmail},
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			svc := newTestService(t)
 			_, err := svc.Register(context.Background(), tc.email)
 			if tc.wantErr == nil {
@@ -42,6 +45,8 @@ func TestService_Register(t *testing.T) {
 }
 
 func TestService_Get(t *testing.T) {
+	t.Parallel()
+
 	svc := newTestService(t)
 	created, err := svc.Register(context.Background(), "mochi@example.com")
 	if err != nil {
@@ -54,11 +59,15 @@ func TestService_Get(t *testing.T) {
 		wantErr error
 	}{
 		{name: "found", id: created.ID, wantErr: nil},
-		{name: "missing", id: "does-not-exist", wantErr: ErrNotFound},
+		{name: "missing", id: "deadbeefdeadbeefdeadbeef", wantErr: ErrNotFound},
+		{name: "invalid id empty", id: "", wantErr: ErrInvalidID},
+		{name: "invalid id non-hex", id: "not-a-hex-id", wantErr: ErrInvalidID},
 	}
 
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 			_, err := svc.Get(context.Background(), tc.id)
 			if tc.wantErr == nil && err != nil {
 				t.Fatalf("Get: unexpected error: %v", err)
@@ -68,4 +77,12 @@ func TestService_Get(t *testing.T) {
 			}
 		})
 	}
+}
+
+func longEmail() string {
+	prefix := make([]byte, maxEmailLength)
+	for i := range prefix {
+		prefix[i] = 'a'
+	}
+	return string(prefix) + "@example.com"
 }

--- a/go-kitty/internal/users/service_test.go
+++ b/go-kitty/internal/users/service_test.go
@@ -1,0 +1,71 @@
+package users
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+)
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	return NewService(NewInMemoryRepository(), slog.New(slog.NewTextHandler(io.Discard, nil)))
+}
+
+func TestService_Register(t *testing.T) {
+	tests := []struct {
+		name    string
+		email   string
+		wantErr error
+	}{
+		{name: "valid", email: "luna@example.com", wantErr: nil},
+		{name: "missing at", email: "lunaexample.com", wantErr: ErrInvalidEmail},
+		{name: "blank", email: "   ", wantErr: ErrInvalidEmail},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newTestService(t)
+			_, err := svc.Register(context.Background(), tc.email)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("Register: unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Register: want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestService_Get(t *testing.T) {
+	svc := newTestService(t)
+	created, err := svc.Register(context.Background(), "mochi@example.com")
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		id      string
+		wantErr error
+	}{
+		{name: "found", id: created.ID, wantErr: nil},
+		{name: "missing", id: "does-not-exist", wantErr: ErrNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := svc.Get(context.Background(), tc.id)
+			if tc.wantErr == nil && err != nil {
+				t.Fatalf("Get: unexpected error: %v", err)
+			}
+			if tc.wantErr != nil && !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Get: want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}

--- a/go-kitty/internal/users/user.go
+++ b/go-kitty/internal/users/user.go
@@ -1,0 +1,10 @@
+package users
+
+import "time"
+
+type User struct {
+	ID        string    `json:"id"`
+	Email     string    `json:"email"`
+	APIKey    string    `json:"-"`
+	CreatedAt time.Time `json:"createdAt"`
+}

--- a/go-kitty/internal/users/user.go
+++ b/go-kitty/internal/users/user.go
@@ -2,6 +2,8 @@ package users
 
 import "time"
 
+// User is the public representation of a registered account.
+// APIKey is never emitted in JSON responses (json:"-").
 type User struct {
 	ID        string    `json:"id"`
 	Email     string    `json:"email"`


### PR DESCRIPTION
Adds a small Go service with HTTP API, in-memory user repository, and supporting packages under `go-kitty/`.