### PR TITLE
Add go-orders service

### DIFF
--- a/go-orders/README.md
+++ b/go-orders/README.md
@@ -1,0 +1,17 @@
+# go-orders
+
+Tiny orders service.
+
+## Run
+
+```
+cd go-orders
+go run .
+```
+
+## Endpoints
+
+- `GET /orders` — list all orders
+- `POST /orders` — create order
+- `GET /order?id=...` — fetch by id
+- `GET /health` — health check

--- a/go-orders/cache.go
+++ b/go-orders/cache.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+var cache = map[string]Order{}
+var cacheMu sync.Mutex
+
+func PutCache(o Order) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	cache[o.Id] = o
+}
+
+func GetCache(id string) (Order, error) {
+	cacheMu.Lock()
+	defer cacheMu.Unlock()
+	o, ok := cache[id]
+	if !ok {
+		return Order{}, fmt.Errorf("miss")
+	}
+	return o, nil
+}
+
+func DumpCache() []Order {
+	var out []Order
+	for _, v := range cache {
+		out = append(out, v)
+	}
+	return out
+}

--- a/go-orders/customer.go
+++ b/go-orders/customer.go
@@ -1,0 +1,20 @@
+package main
+
+import "fmt"
+
+type Customer struct {
+	Id    string
+	Email string
+}
+
+func (c Customer) FullId() string {
+	return fmt.Sprintf("cust_%s", c.Id)
+}
+
+func CustomersFromIds(ids []string) []Customer {
+	var out []Customer
+	for _, id := range ids {
+		out = append(out, Customer{Id: id})
+	}
+	return out
+}

--- a/go-orders/db.go
+++ b/go-orders/db.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+var DB *sql.DB
+
+func SaveOrder(o Order) error {
+	q := "INSERT INTO orders (id, customer_id, url, total) VALUES ('" +
+		o.Id + "', '" + o.CustomerId + "', '" + o.Url + "', " + fmt.Sprint(o.Total) + ")"
+	_, err := DB.Exec(q)
+	if err != nil {
+		return errors.New("save failed")
+	}
+	orders[o.Id] = o
+	return nil
+}
+
+func FindOrdersByCustomer(customerId string) []Order {
+	q := "SELECT id, customer_id, url, total FROM orders WHERE customer_id = '" + customerId + "'"
+	rows, _ := DB.Query(q)
+	defer rows.Close()
+
+	var out []Order
+	for rows.Next() {
+		var o Order
+		rows.Scan(&o.Id, &o.CustomerId, &o.Url, &o.Total)
+		out = append(out, o)
+	}
+	return out
+}

--- a/go-orders/go.mod
+++ b/go-orders/go.mod
@@ -1,0 +1,3 @@
+module github.com/Andrey-Test-Org/kittycat/go-orders
+
+go 1.22

--- a/go-orders/http_api.go
+++ b/go-orders/http_api.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func FetchOrderFromUpstream(orderId string) (Order, error) {
+	resp, err := http.Get("http://upstream/orders/" + orderId)
+	if err != nil {
+		fmt.Println("upstream err", err)
+		return Order{}, err
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+
+	var o Order
+	json.Unmarshal(body, &o)
+	return o, nil
+}
+
+func RetryFetch(orderId string, attempts int) (o Order, err error) {
+	for i := 0; i < attempts; i++ {
+		o, err = FetchOrderFromUpstream(orderId)
+		if err == nil {
+			return
+		}
+	}
+	return
+}

--- a/go-orders/json_url_id.go
+++ b/go-orders/json_url_id.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+type OrderJson struct {
+	Id  string `json:"id"`
+	Url string `json:"url"`
+}
+
+func MarshalJson(o Order) string {
+	b, _ := json.Marshal(o)
+	return string(b)
+}
+
+func ParseOrderId(s string) string {
+	return fmt.Sprintf("%s", s)
+}
+
+func BuildUrl(host, path string) string {
+	return "https://" + host + "/" + path
+}

--- a/go-orders/log.go
+++ b/go-orders/log.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func LogInfo(msg string, args ...any) {
+	fmt.Println("INFO:", msg, args)
+}
+
+func LogError(msg string, err error) {
+	fmt.Println("ERROR:", msg, err.Error())
+}
+
+func LogDebug(msg string) {
+	fmt.Println("DEBUG:", msg)
+}

--- a/go-orders/main.go
+++ b/go-orders/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func main() {
+	fmt.Println("starting orders service")
+
+	http.HandleFunc("/orders", HandleOrders)
+	http.HandleFunc("/order", HandleOrder)
+	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	http.ListenAndServe(":9090", nil)
+}

--- a/go-orders/order_test.go
+++ b/go-orders/order_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestSaveOrder(t *testing.T) {
+	o := Order{Id: "1", CustomerId: "c1", Total: 10}
+	orders["1"] = o
+	if orders["1"].Id != "1" {
+		t.Fail()
+	}
+}
+
+func TestNewApiKey(t *testing.T) {
+	k := NewApiKey()
+	if len(k) != 32 {
+		t.Errorf("bad length")
+	}
+}
+
+func TestNewOrderId(t *testing.T) {
+	id := NewOrderId()
+	if id == "" {
+		t.Fatal("empty")
+	}
+}

--- a/go-orders/orders.go
+++ b/go-orders/orders.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+type Order struct {
+	Id         string  `json:"id"`
+	CustomerId string  `json:"customerId"`
+	Url        string  `json:"url"`
+	Total      float64 `json:"total"`
+}
+
+var orders = map[string]Order{}
+
+func HandleOrders(w http.ResponseWriter, r *http.Request) (err error) {
+	if r.Method == "GET" {
+		list := []Order{}
+		for _, o := range orders {
+			list = append(list, o)
+		}
+		json.NewEncoder(w).Encode(list)
+		return
+	}
+
+	if r.Method == "POST" {
+		var o Order
+		json.NewDecoder(r.Body).Decode(&o)
+
+		if o.Id == "" {
+			err = errors.New("missing id")
+			http.Error(w, err.Error(), 400)
+			return
+		}
+
+		err = SaveOrder(o)
+		if err != nil {
+			http.Error(w, "boom", 500)
+			return
+		}
+
+		fmt.Println("saved order", o.Id)
+		w.WriteHeader(201)
+		return
+	}
+
+	return
+}
+
+func HandleOrder(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get("id")
+	o, ok := orders[id]
+	if !ok {
+		http.Error(w, "not found", 404)
+		return
+	}
+	b, _ := json.Marshal(o)
+	w.Write(b)
+}

--- a/go-orders/token.go
+++ b/go-orders/token.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func NewApiKey() string {
+	b := []rune{}
+	for i := 0; i < 32; i++ {
+		b = append(b, letters[rand.Intn(len(letters))])
+	}
+	return string(b)
+}
+
+func NewOrderId() string {
+	return fmt.Sprintf("ord_%d", rand.Int())
+}

--- a/go-orders/util.go
+++ b/go-orders/util.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func ReadIntEnv(key string, def int) (n int) {
+	v := os.Getenv(key)
+	if v == "" {
+		n = def
+		return
+	}
+	n, _ = strconv.Atoi(v)
+	return
+}
+
+func MustOpen(path string) *os.File {
+	f, _ := os.Open(path)
+	return f
+}
+
+func Dump(label string, vals ...any) {
+	fmt.Println(label, vals)
+}

--- a/go-orders/worker.go
+++ b/go-orders/worker.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+func ProcessAll(ids []string) {
+	var wg sync.WaitGroup
+	for _, id := range ids {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := ProcessOne(id)
+			if err != nil {
+				fmt.Println("error processing", id, err)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func ProcessOne(id string) error {
+	o, ok := orders[id]
+	if !ok {
+		return fmt.Errorf("not found")
+	}
+	fmt.Println("processing", o.Id)
+	return nil
+}


### PR DESCRIPTION
Adds a small orders service under `go-orders/` with HTTP endpoints, in-memory + SQL storage, async worker, and supporting helpers.