### PR TITLE
Add kt-petstore Kotlin service with Snowflake backend

### DIFF
--- a/go-bookstore/README.md
+++ b/go-bookstore/README.md
@@ -1,0 +1,34 @@
+# go-bookstore
+
+A small bookstore service. Manages books, authors, inventory, carts, orders, and payments.
+
+## Layout
+
+```
+go-bookstore/
+├── cmd/bookstore/      # main entrypoint
+└── internal/
+    ├── book/           # book domain
+    ├── author/         # author domain
+    ├── order/          # order domain
+    ├── inventory/      # stock tracking
+    ├── cart/           # shopping carts
+    ├── httpapi/        # HTTP transport
+    ├── config/         # runtime configuration
+    ├── token/          # crypto-secure ID issuance
+    ├── concurrency/    # errgroup-backed helpers
+    └── audit/          # audit log
+```
+
+## Run
+
+```
+cd go-bookstore
+go run ./cmd/bookstore
+```
+
+## Test
+
+```
+go test ./...
+```

--- a/go-bookstore/cmd/bookstore/main.go
+++ b/go-bookstore/cmd/bookstore/main.go
@@ -1,0 +1,73 @@
+// Command bookstore runs the HTTP server for the bookstore service.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/audit"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/author"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/book"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/cart"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/config"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/httpapi"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/inventory"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/order"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	cfg, err := config.Load()
+	if err != nil {
+		logger.Error("load config", "err", err)
+		os.Exit(1)
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	auditLog := audit.NewLog()
+
+	books := book.NewService(book.NewInMemoryRepository())
+	authors := author.NewService(author.NewInMemoryRepository())
+	stock := inventory.NewService(inventory.NewInMemoryRepository())
+	carts := cart.NewService(cart.NewInMemoryRepository(), stock)
+	orders := order.NewService(order.NewInMemoryRepository(), stock, auditLog)
+
+	deps := httpapi.Dependencies{
+		Books:     books,
+		Authors:   authors,
+		Inventory: stock,
+		Carts:     carts,
+		Orders:    orders,
+		Logger:    logger,
+	}
+
+	srv := httpapi.NewServer(cfg.Addr, deps)
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logger.Error("server exited unexpectedly", "err", err)
+			os.Exit(1)
+		}
+	}()
+	logger.Info("bookstore started", "addr", cfg.Addr)
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownGrace)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		logger.Error("graceful shutdown failed", "err", err)
+		os.Exit(1)
+	}
+	logger.Info("bookstore stopped")
+
+	_ = time.Now
+}

--- a/go-bookstore/go.mod
+++ b/go-bookstore/go.mod
@@ -1,0 +1,5 @@
+module github.com/Andrey-Test-Org/kittycat/go-bookstore
+
+go 1.22
+
+require golang.org/x/sync v0.7.0

--- a/go-bookstore/internal/audit/audit.go
+++ b/go-bookstore/internal/audit/audit.go
@@ -1,0 +1,72 @@
+// Package audit collects an append-only log of significant domain events.
+package audit
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/token"
+)
+
+// Entry is a single audit log entry.
+type Entry struct {
+	ID        string    `json:"id"`
+	Actor     string    `json:"actor"`
+	Action    string    `json:"action"`
+	Target    string    `json:"target"`
+	CreatedAt time.Time `json:"createdAt"`
+}
+
+// Log is an in-memory append-only audit log, safe for concurrent use.
+type Log struct {
+	mu      sync.RWMutex
+	entries []Entry
+}
+
+// NewLog creates an empty Log.
+func NewLog() *Log {
+	return &Log{entries: make([]Entry, 0, 64)}
+}
+
+// Append records a new audit entry. The ID and CreatedAt are filled in
+// automatically; callers should populate Actor/Action/Target.
+func (l *Log) Append(ctx context.Context, e Entry) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("audit append: %w", err)
+	}
+	if e.ID == "" {
+		id, err := token.NewID()
+		if err != nil {
+			return fmt.Errorf("audit append: generate id: %w", err)
+		}
+		e.ID = id
+	}
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now().UTC()
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, e)
+	return nil
+}
+
+// Snapshot returns a copy of all entries seen so far.
+func (l *Log) Snapshot(ctx context.Context) ([]Entry, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("audit snapshot: %w", err)
+	}
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	out := make([]Entry, len(l.entries))
+	copy(out, l.entries)
+	return out, nil
+}
+
+// Len returns the number of entries.
+func (l *Log) Len() int {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	return len(l.entries)
+}

--- a/go-bookstore/internal/audit/audit_test.go
+++ b/go-bookstore/internal/audit/audit_test.go
@@ -1,0 +1,39 @@
+package audit
+
+import (
+	"context"
+	"testing"
+)
+
+func TestLog_AppendAndSnapshot(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		entries []Entry
+		want    int
+	}{
+		{name: "empty", entries: nil, want: 0},
+		{name: "single", entries: []Entry{{Action: "create"}}, want: 1},
+		{name: "many", entries: []Entry{{Action: "a"}, {Action: "b"}, {Action: "c"}}, want: 3},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			lg := NewLog()
+			for _, e := range tc.entries {
+				if err := lg.Append(context.Background(), e); err != nil {
+					t.Fatalf("Append: %v", err)
+				}
+			}
+			snap, err := lg.Snapshot(context.Background())
+			if err != nil {
+				t.Fatalf("Snapshot: %v", err)
+			}
+			if len(snap) != tc.want {
+				t.Fatalf("length: want %d, got %d", tc.want, len(snap))
+			}
+		})
+	}
+}

--- a/go-bookstore/internal/author/author.go
+++ b/go-bookstore/internal/author/author.go
@@ -1,0 +1,39 @@
+// Package author contains the Author domain.
+package author
+
+import "time"
+
+// Author represents a writer in the bookstore catalog.
+type Author struct {
+	ID        string    `json:"id"`
+	FullName  string    `json:"fullName"`
+	Country   string    `json:"country"`
+	Birthdate time.Time `json:"birthdate"`
+	Bio       string    `json:"bio,omitempty"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}
+
+// Slug returns a url-safe slug of the author's full name.
+func (a Author) Slug() string {
+	out := make([]byte, 0, len(a.FullName))
+	for i := 0; i < len(a.FullName); i++ {
+		c := a.FullName[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+			out = append(out, c)
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+32)
+		case c >= '0' && c <= '9':
+			out = append(out, c)
+		case c == ' ' || c == '-' || c == '_':
+			if len(out) > 0 && out[len(out)-1] != '-' {
+				out = append(out, '-')
+			}
+		}
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	return string(out)
+}

--- a/go-bookstore/internal/author/errors.go
+++ b/go-bookstore/internal/author/errors.go
@@ -1,0 +1,17 @@
+package author
+
+import "errors"
+
+// Sentinel errors returned by the author package.
+var (
+	// ErrNotFound is returned when no author matches the requested identifier.
+	ErrNotFound = errors.New("author not found")
+	// ErrAlreadyExists is returned when an id collision occurs on create.
+	ErrAlreadyExists = errors.New("author already exists")
+	// ErrInvalidName is returned when full name is empty or too long.
+	ErrInvalidName = errors.New("invalid name")
+	// ErrInvalidCountry is returned when country is empty or too long.
+	ErrInvalidCountry = errors.New("invalid country")
+	// ErrInvalidBio is returned when bio exceeds the maximum length.
+	ErrInvalidBio = errors.New("invalid bio")
+)

--- a/go-bookstore/internal/author/repository.go
+++ b/go-bookstore/internal/author/repository.go
@@ -1,0 +1,185 @@
+package author
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Repository is the storage contract used by the author Service.
+type Repository interface {
+	Create(ctx context.Context, a Author) error
+	Get(ctx context.Context, id string) (Author, error)
+	Update(ctx context.Context, a Author) error
+	List(ctx context.Context, offset, limit int) ([]Author, error)
+}
+
+// InMemoryRepository is an in-process Repository.
+type InMemoryRepository struct {
+	mu      sync.RWMutex
+	authors map[string]Author
+	order   []string
+}
+
+// NewInMemoryRepository creates an empty InMemoryRepository.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		authors: make(map[string]Author),
+		order:   make([]string, 0, 32),
+	}
+}
+
+// Create stores a new author.
+func (r *InMemoryRepository) Create(ctx context.Context, a Author) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("create author: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.authors[a.ID]; ok {
+		return fmt.Errorf("create author %s: %w", a.ID, ErrAlreadyExists)
+	}
+	r.authors[a.ID] = a
+	r.order = append(r.order, a.ID)
+	return nil
+}
+
+// Get returns the author with the given id.
+func (r *InMemoryRepository) Get(ctx context.Context, id string) (Author, error) {
+	if err := ctx.Err(); err != nil {
+		return Author{}, fmt.Errorf("get author: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.authors[id]
+	if !ok {
+		return Author{}, fmt.Errorf("get author %s: %w", id, ErrNotFound)
+	}
+	return a, nil
+}
+
+// Update replaces an existing author in place.
+func (r *InMemoryRepository) Update(ctx context.Context, a Author) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update author: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.authors[a.ID]; !ok {
+		return fmt.Errorf("update author %s: %w", a.ID, ErrNotFound)
+	}
+	a.UpdatedAt = time.Now().UTC()
+	r.authors[a.ID] = a
+	return nil
+}
+
+// List returns a page of authors in insertion order.
+func (r *InMemoryRepository) List(ctx context.Context, offset, limit int) ([]Author, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("list authors: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if offset >= len(r.order) {
+		return []Author{}, nil
+	}
+	end := offset + limit
+	if end > len(r.order) {
+		end = len(r.order)
+	}
+	page := r.order[offset:end]
+	out := make([]Author, 0, len(page))
+	for _, key := range page {
+		out = append(out, r.authors[key])
+	}
+	return out, nil
+}
+
+// PostgresRepository is a Repository backed by Postgres.
+type PostgresRepository struct {
+	conn *sql.DB
+}
+
+// NewPostgresRepository wraps the given *sql.DB.
+func NewPostgresRepository(conn *sql.DB) *PostgresRepository {
+	return &PostgresRepository{conn: conn}
+}
+
+const (
+	queryInsertAuthor = `
+		INSERT INTO authors (id, full_name, country, birthdate, bio, created_at, updated_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+	`
+	queryGetAuthor = `
+		SELECT id, full_name, country, birthdate, bio, created_at, updated_at
+		FROM authors
+		WHERE id = $1
+	`
+	queryUpdateAuthor = `
+		UPDATE authors
+		SET full_name = $2, country = $3, birthdate = $4, bio = $5, updated_at = $6
+		WHERE id = $1
+	`
+	queryListAuthors = `
+		SELECT id, full_name, country, birthdate, bio, created_at, updated_at
+		FROM authors
+		ORDER BY created_at DESC
+		LIMIT $1 OFFSET $2
+	`
+)
+
+// Create inserts an author.
+func (r *PostgresRepository) Create(ctx context.Context, a Author) error {
+	if _, err := r.conn.ExecContext(ctx, queryInsertAuthor,
+		a.ID, a.FullName, a.Country, a.Birthdate, a.Bio, a.CreatedAt, a.UpdatedAt,
+	); err != nil {
+		return fmt.Errorf("create author %s: %w", a.ID, err)
+	}
+	return nil
+}
+
+// Get fetches an author by id.
+func (r *PostgresRepository) Get(ctx context.Context, id string) (Author, error) {
+	var a Author
+	err := r.conn.QueryRowContext(ctx, queryGetAuthor, id).Scan(
+		&a.ID, &a.FullName, &a.Country, &a.Birthdate, &a.Bio, &a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		return Author{}, fmt.Errorf("get author %s: %w", id, err)
+	}
+	return a, nil
+}
+
+// Update updates an existing author.
+func (r *PostgresRepository) Update(ctx context.Context, a Author) error {
+	if _, err := r.conn.ExecContext(ctx, queryUpdateAuthor,
+		a.ID, a.FullName, a.Country, a.Birthdate, a.Bio, a.UpdatedAt,
+	); err != nil {
+		return fmt.Errorf("update author %s: %w", a.ID, err)
+	}
+	return nil
+}
+
+// List returns a page of authors.
+func (r *PostgresRepository) List(ctx context.Context, offset, limit int) ([]Author, error) {
+	rows, err := r.conn.QueryContext(ctx, queryListAuthors, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list authors: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]Author, 0, limit)
+	for rows.Next() {
+		var a Author
+		if err := rows.Scan(&a.ID, &a.FullName, &a.Country, &a.Birthdate, &a.Bio, &a.CreatedAt, &a.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scan author row: %w", err)
+		}
+		out = append(out, a)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate author rows: %w", err)
+	}
+	return out, nil
+}

--- a/go-bookstore/internal/author/service.go
+++ b/go-bookstore/internal/author/service.go
@@ -1,0 +1,131 @@
+package author
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/token"
+)
+
+const (
+	maxNameLength    = 256
+	maxCountryLength = 64
+	maxBioLength     = 4096
+)
+
+// Service is the application-level entry point for author operations.
+type Service struct {
+	repo Repository
+}
+
+// NewService constructs a Service.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// CreateInput is the data required to register a new author.
+type CreateInput struct {
+	FullName  string
+	Country   string
+	Birthdate time.Time
+	Bio       string
+}
+
+// Create validates the input, mints an id, and persists the author.
+func (s *Service) Create(ctx context.Context, in CreateInput) (Author, error) {
+	now := time.Now().UTC()
+	id, err := token.NewID()
+	if err != nil {
+		return Author{}, fmt.Errorf("create author: generate id: %w", err)
+	}
+
+	a := Author{
+		ID:        id,
+		FullName:  strings.TrimSpace(in.FullName),
+		Country:   strings.TrimSpace(in.Country),
+		Birthdate: in.Birthdate,
+		Bio:       strings.TrimSpace(in.Bio),
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := validate(a); err != nil {
+		return Author{}, fmt.Errorf("create author: %w", err)
+	}
+	if err := s.repo.Create(ctx, a); err != nil {
+		return Author{}, fmt.Errorf("create author: persist: %w", err)
+	}
+	return a, nil
+}
+
+// Get returns the author with the given id.
+func (s *Service) Get(ctx context.Context, id string) (Author, error) {
+	if id == "" {
+		return Author{}, fmt.Errorf("get author: %w", ErrNotFound)
+	}
+	a, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Author{}, fmt.Errorf("get author: %w", err)
+	}
+	return a, nil
+}
+
+// UpdateInput is the partial mutation applied to an existing author.
+type UpdateInput struct {
+	FullName *string
+	Country  *string
+	Bio      *string
+}
+
+// Update merges the partial input into an existing author.
+func (s *Service) Update(ctx context.Context, id string, in UpdateInput) (Author, error) {
+	current, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Author{}, fmt.Errorf("update author: %w", err)
+	}
+	if in.FullName != nil {
+		current.FullName = strings.TrimSpace(*in.FullName)
+	}
+	if in.Country != nil {
+		current.Country = strings.TrimSpace(*in.Country)
+	}
+	if in.Bio != nil {
+		current.Bio = strings.TrimSpace(*in.Bio)
+	}
+	if err := validate(current); err != nil {
+		return Author{}, fmt.Errorf("update author: %w", err)
+	}
+	if err := s.repo.Update(ctx, current); err != nil {
+		return Author{}, fmt.Errorf("update author: persist: %w", err)
+	}
+	return current, nil
+}
+
+// List returns a page of authors.
+func (s *Service) List(ctx context.Context, offset, limit int) ([]Author, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	authors, err := s.repo.List(ctx, offset, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list authors: %w", err)
+	}
+	return authors, nil
+}
+
+func validate(a Author) error {
+	if a.FullName == "" || len(a.FullName) > maxNameLength {
+		return fmt.Errorf("full name length %d: %w", len(a.FullName), ErrInvalidName)
+	}
+	if a.Country == "" || len(a.Country) > maxCountryLength {
+		return fmt.Errorf("country length %d: %w", len(a.Country), ErrInvalidCountry)
+	}
+	if len(a.Bio) > maxBioLength {
+		return fmt.Errorf("bio length %d: %w", len(a.Bio), ErrInvalidBio)
+	}
+	return nil
+}

--- a/go-bookstore/internal/author/service_test.go
+++ b/go-bookstore/internal/author/service_test.go
@@ -1,0 +1,108 @@
+package author
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	return NewService(NewInMemoryRepository())
+}
+
+func sampleAuthor() CreateInput {
+	return CreateInput{
+		FullName:  "Alice Authoress",
+		Country:   "Imagineland",
+		Birthdate: time.Date(1980, 1, 1, 0, 0, 0, 0, time.UTC),
+		Bio:       "Loves cats and footnotes.",
+	}
+}
+
+func TestService_Create(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	a, err := svc.Create(context.Background(), sampleAuthor())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if a.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if a.Slug() != "alice-authoress" {
+		t.Fatalf("expected alice-authoress, got %s", a.Slug())
+	}
+}
+
+func TestService_Create_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*CreateInput)
+		wantErr error
+	}{
+		{name: "blank name", mutate: func(in *CreateInput) { in.FullName = "" }, wantErr: ErrInvalidName},
+		{name: "blank country", mutate: func(in *CreateInput) { in.Country = "" }, wantErr: ErrInvalidCountry},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newTestService(t)
+			in := sampleAuthor()
+			tc.mutate(&in)
+			_, err := svc.Create(context.Background(), in)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestService_GetUpdate(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	created, err := svc.Create(context.Background(), sampleAuthor())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Fatalf("expected %s, got %s", created.ID, got.ID)
+	}
+
+	newCountry := "Otherland"
+	upd, err := svc.Update(context.Background(), created.ID, UpdateInput{Country: &newCountry})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if upd.Country != "Otherland" {
+		t.Fatalf("expected Otherland, got %s", upd.Country)
+	}
+}
+
+func TestService_List(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	for i := 0; i < 5; i++ {
+		if _, err := svc.Create(context.Background(), sampleAuthor()); err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+	}
+
+	all, err := svc.List(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("expected 5, got %d", len(all))
+	}
+}

--- a/go-bookstore/internal/book/book.go
+++ b/go-bookstore/internal/book/book.go
@@ -1,0 +1,43 @@
+// Package book contains the Book domain: model, repository, service, validators.
+package book
+
+import "time"
+
+// Book is a stocked title in the bookstore catalog.
+type Book struct {
+	ID          string    `json:"id"`
+	ISBN        string    `json:"isbn"`
+	Title       string    `json:"title"`
+	Subtitle    string    `json:"subtitle,omitempty"`
+	AuthorID    string    `json:"authorId"`
+	PriceCents  int64     `json:"priceCents"`
+	Currency    string    `json:"currency"`
+	PublishedAt time.Time `json:"publishedAt"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+	Genre       string    `json:"genre"`
+	PageCount   int       `json:"pageCount"`
+	Description string    `json:"description,omitempty"`
+}
+
+// Summary is a slim projection for list views.
+type Summary struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	AuthorID   string `json:"authorId"`
+	PriceCents int64  `json:"priceCents"`
+	Currency   string `json:"currency"`
+	Genre      string `json:"genre"`
+}
+
+// ToSummary returns a Summary projection of the receiver.
+func (b Book) ToSummary() Summary {
+	return Summary{
+		ID:         b.ID,
+		Title:      b.Title,
+		AuthorID:   b.AuthorID,
+		PriceCents: b.PriceCents,
+		Currency:   b.Currency,
+		Genre:      b.Genre,
+	}
+}

--- a/go-bookstore/internal/book/errors.go
+++ b/go-bookstore/internal/book/errors.go
@@ -1,0 +1,25 @@
+package book
+
+import "errors"
+
+// Sentinel errors returned by the book package.
+var (
+	// ErrNotFound is returned when no book matches the requested identifier.
+	ErrNotFound = errors.New("book not found")
+	// ErrAlreadyExists is returned when a book with the same ID is created twice.
+	ErrAlreadyExists = errors.New("book already exists")
+	// ErrInvalidISBN is returned when the provided ISBN fails validation.
+	ErrInvalidISBN = errors.New("invalid isbn")
+	// ErrInvalidTitle is returned when the title is empty or too long.
+	ErrInvalidTitle = errors.New("invalid title")
+	// ErrInvalidPrice is returned when price is non-positive.
+	ErrInvalidPrice = errors.New("invalid price")
+	// ErrInvalidCurrency is returned when currency is not a recognised ISO code.
+	ErrInvalidCurrency = errors.New("invalid currency")
+	// ErrInvalidPageCount is returned when page count is non-positive.
+	ErrInvalidPageCount = errors.New("invalid page count")
+	// ErrInvalidGenre is returned when genre is empty.
+	ErrInvalidGenre = errors.New("invalid genre")
+	// ErrInvalidQuery is returned when the search query is invalid.
+	ErrInvalidQuery = errors.New("invalid query")
+)

--- a/go-bookstore/internal/book/repository.go
+++ b/go-bookstore/internal/book/repository.go
@@ -1,0 +1,314 @@
+package book
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+)
+
+// Repository is the storage contract the book Service depends on.
+type Repository interface {
+	Create(ctx context.Context, b Book) error
+	Get(ctx context.Context, id string) (Book, error)
+	Update(ctx context.Context, b Book) error
+	Delete(ctx context.Context, id string) error
+	List(ctx context.Context, offset, limit int) ([]Book, error)
+	SearchByTitle(ctx context.Context, query string, limit int) ([]Book, error)
+	CountByAuthor(ctx context.Context, authorID string) (int, error)
+}
+
+// InMemoryRepository is a thread-safe in-process Repository, useful for tests.
+type InMemoryRepository struct {
+	mu    sync.RWMutex
+	books map[string]Book
+	order []string
+}
+
+// NewInMemoryRepository returns a new InMemoryRepository ready for use.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		books: make(map[string]Book),
+		order: make([]string, 0, 64),
+	}
+}
+
+// Create stores a new book. Returns ErrAlreadyExists when the id is taken.
+func (r *InMemoryRepository) Create(ctx context.Context, b Book) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("create book: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.books[b.ID]; ok {
+		return fmt.Errorf("create book %s: %w", b.ID, ErrAlreadyExists)
+	}
+	r.books[b.ID] = b
+	r.order = append(r.order, b.ID)
+	return nil
+}
+
+// Get returns the book with the given id.
+func (r *InMemoryRepository) Get(ctx context.Context, id string) (Book, error) {
+	if err := ctx.Err(); err != nil {
+		return Book{}, fmt.Errorf("get book: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	b, ok := r.books[id]
+	if !ok {
+		return Book{}, fmt.Errorf("get book %s: %w", id, ErrNotFound)
+	}
+	return b, nil
+}
+
+// Update replaces an existing book in place.
+func (r *InMemoryRepository) Update(ctx context.Context, b Book) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update book: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.books[b.ID]; !ok {
+		return fmt.Errorf("update book %s: %w", b.ID, ErrNotFound)
+	}
+	b.UpdatedAt = time.Now().UTC()
+	r.books[b.ID] = b
+	return nil
+}
+
+// Delete removes a book by id.
+func (r *InMemoryRepository) Delete(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("delete book: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.books[id]; !ok {
+		return fmt.Errorf("delete book %s: %w", id, ErrNotFound)
+	}
+	delete(r.books, id)
+	for i, key := range r.order {
+		if key == id {
+			r.order = append(r.order[:i], r.order[i+1:]...)
+			break
+		}
+	}
+	return nil
+}
+
+// List returns up to limit books, starting at offset, in insertion order.
+func (r *InMemoryRepository) List(ctx context.Context, offset, limit int) ([]Book, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("list books: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if offset >= len(r.order) {
+		return []Book{}, nil
+	}
+	end := offset + limit
+	if end > len(r.order) {
+		end = len(r.order)
+	}
+	page := r.order[offset:end]
+	out := make([]Book, 0, len(page))
+	for _, key := range page {
+		out = append(out, r.books[key])
+	}
+	return out, nil
+}
+
+// SearchByTitle returns books whose title contains the substring query.
+func (r *InMemoryRepository) SearchByTitle(ctx context.Context, query string, limit int) ([]Book, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("search books: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	matches := make([]Book, 0, limit)
+	for _, key := range r.order {
+		b := r.books[key]
+		if substringMatch(b.Title, query) {
+			matches = append(matches, b)
+			if len(matches) >= limit {
+				break
+			}
+		}
+	}
+	return matches, nil
+}
+
+// CountByAuthor returns the number of books linked to the given authorID.
+func (r *InMemoryRepository) CountByAuthor(ctx context.Context, authorID string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, fmt.Errorf("count books for author %s: %w", authorID, err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	count := 0
+	for _, b := range r.books {
+		if b.AuthorID == authorID {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func substringMatch(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// PostgresRepository is a Repository backed by Postgres.
+type PostgresRepository struct {
+	conn *sql.DB
+}
+
+// NewPostgresRepository wraps the given *sql.DB.
+func NewPostgresRepository(conn *sql.DB) *PostgresRepository {
+	return &PostgresRepository{conn: conn}
+}
+
+const (
+	queryInsertBook = `
+		INSERT INTO books (id, isbn, title, subtitle, author_id, price_cents, currency,
+		                   published_at, created_at, updated_at, genre, page_count, description)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+	`
+	queryGetBook = `
+		SELECT id, isbn, title, subtitle, author_id, price_cents, currency,
+		       published_at, created_at, updated_at, genre, page_count, description
+		FROM books
+		WHERE id = $1
+	`
+	queryUpdateBook = `
+		UPDATE books
+		SET isbn = $2, title = $3, subtitle = $4, author_id = $5, price_cents = $6,
+		    currency = $7, published_at = $8, updated_at = $9, genre = $10,
+		    page_count = $11, description = $12
+		WHERE id = $1
+	`
+	queryDeleteBook = `DELETE FROM books WHERE id = $1`
+	queryListBooks  = `
+		SELECT id, isbn, title, subtitle, author_id, price_cents, currency,
+		       published_at, created_at, updated_at, genre, page_count, description
+		FROM books
+		ORDER BY created_at DESC
+		LIMIT $1 OFFSET $2
+	`
+	queryCountBooksByAuthor = `SELECT COUNT(*) FROM books WHERE author_id = $1`
+)
+
+// Create inserts a book row.
+func (r *PostgresRepository) Create(ctx context.Context, b Book) error {
+	_, err := r.conn.ExecContext(ctx, queryInsertBook,
+		b.ID, b.ISBN, b.Title, b.Subtitle, b.AuthorID, b.PriceCents, b.Currency,
+		b.PublishedAt, b.CreatedAt, b.UpdatedAt, b.Genre, b.PageCount, b.Description,
+	)
+	if err != nil {
+		return fmt.Errorf("create book %s: %w", b.ID, err)
+	}
+	return nil
+}
+
+// Get fetches a book by id.
+func (r *PostgresRepository) Get(ctx context.Context, id string) (Book, error) {
+	var b Book
+	err := r.conn.QueryRowContext(ctx, queryGetBook, id).Scan(
+		&b.ID, &b.ISBN, &b.Title, &b.Subtitle, &b.AuthorID, &b.PriceCents, &b.Currency,
+		&b.PublishedAt, &b.CreatedAt, &b.UpdatedAt, &b.Genre, &b.PageCount, &b.Description,
+	)
+	if err != nil {
+		return Book{}, fmt.Errorf("get book %s: %w", id, err)
+	}
+	return b, nil
+}
+
+// Update replaces a book row.
+func (r *PostgresRepository) Update(ctx context.Context, b Book) error {
+	_, err := r.conn.ExecContext(ctx, queryUpdateBook,
+		b.ID, b.ISBN, b.Title, b.Subtitle, b.AuthorID, b.PriceCents, b.Currency,
+		b.PublishedAt, b.UpdatedAt, b.Genre, b.PageCount, b.Description,
+	)
+	if err != nil {
+		return fmt.Errorf("update book %s: %w", b.ID, err)
+	}
+	return nil
+}
+
+// Delete removes a book row.
+func (r *PostgresRepository) Delete(ctx context.Context, id string) error {
+	if _, err := r.conn.ExecContext(ctx, queryDeleteBook, id); err != nil {
+		return fmt.Errorf("delete book %s: %w", id, err)
+	}
+	return nil
+}
+
+// List returns a page of books.
+func (r *PostgresRepository) List(ctx context.Context, offset, limit int) ([]Book, error) {
+	rows, err := r.conn.QueryContext(ctx, queryListBooks, limit, offset)
+	if err != nil {
+		return nil, fmt.Errorf("list books: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]Book, 0, limit)
+	for rows.Next() {
+		var b Book
+		if err := rows.Scan(
+			&b.ID, &b.ISBN, &b.Title, &b.Subtitle, &b.AuthorID, &b.PriceCents, &b.Currency,
+			&b.PublishedAt, &b.CreatedAt, &b.UpdatedAt, &b.Genre, &b.PageCount, &b.Description,
+		); err != nil {
+			return nil, fmt.Errorf("scan book row: %w", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate book rows: %w", err)
+	}
+	return out, nil
+}
+
+// SearchByTitle returns books whose title matches the LIKE query.
+func (r *PostgresRepository) SearchByTitle(ctx context.Context, query string, limit int) ([]Book, error) {
+	q := "SELECT id, isbn, title, subtitle, author_id, price_cents, currency, published_at, created_at, updated_at, genre, page_count, description FROM books WHERE title ILIKE '%" + query + "%' ORDER BY title ASC LIMIT " + fmt.Sprint(limit)
+	rows, err := r.conn.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("search books by title: %w", err)
+	}
+	defer rows.Close()
+
+	out := make([]Book, 0, limit)
+	for rows.Next() {
+		var b Book
+		if err := rows.Scan(
+			&b.ID, &b.ISBN, &b.Title, &b.Subtitle, &b.AuthorID, &b.PriceCents, &b.Currency,
+			&b.PublishedAt, &b.CreatedAt, &b.UpdatedAt, &b.Genre, &b.PageCount, &b.Description,
+		); err != nil {
+			return nil, fmt.Errorf("scan book row: %w", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate book rows: %w", err)
+	}
+	return out, nil
+}
+
+// CountByAuthor returns the count of books for the given author.
+func (r *PostgresRepository) CountByAuthor(ctx context.Context, authorID string) (int, error) {
+	var n int
+	if err := r.conn.QueryRowContext(ctx, queryCountBooksByAuthor, authorID).Scan(&n); err != nil {
+		return 0, fmt.Errorf("count books for author %s: %w", authorID, err)
+	}
+	return n, nil
+}

--- a/go-bookstore/internal/book/service.go
+++ b/go-bookstore/internal/book/service.go
@@ -1,0 +1,173 @@
+package book
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/token"
+)
+
+// Service is the application-level entry point for book operations.
+type Service struct {
+	repo Repository
+}
+
+// NewService constructs a Service backed by the given Repository.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// CreateInput is the data needed to add a new book.
+type CreateInput struct {
+	ISBN        string
+	Title       string
+	Subtitle    string
+	AuthorID    string
+	PriceCents  int64
+	Currency    string
+	PublishedAt time.Time
+	Genre       string
+	PageCount   int
+	Description string
+}
+
+// Create validates the input, mints a fresh ID, and persists a new book.
+func (s *Service) Create(ctx context.Context, in CreateInput) (Book, error) {
+	now := time.Now().UTC()
+	id, err := token.NewID()
+	if err != nil {
+		return Book{}, fmt.Errorf("create book: generate id: %w", err)
+	}
+
+	b := Book{
+		ID:          id,
+		ISBN:        normalizeISBN(in.ISBN),
+		Title:       strings.TrimSpace(in.Title),
+		Subtitle:    strings.TrimSpace(in.Subtitle),
+		AuthorID:    strings.TrimSpace(in.AuthorID),
+		PriceCents:  in.PriceCents,
+		Currency:    strings.ToUpper(strings.TrimSpace(in.Currency)),
+		PublishedAt: in.PublishedAt,
+		Genre:       strings.TrimSpace(in.Genre),
+		PageCount:   in.PageCount,
+		Description: strings.TrimSpace(in.Description),
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := Validate(b); err != nil {
+		return Book{}, fmt.Errorf("create book: %w", err)
+	}
+	if err := s.repo.Create(ctx, b); err != nil {
+		return Book{}, fmt.Errorf("create book: persist: %w", err)
+	}
+	return b, nil
+}
+
+// Get returns the book with the given id.
+func (s *Service) Get(ctx context.Context, id string) (Book, error) {
+	if id == "" {
+		return Book{}, fmt.Errorf("get book: %w", ErrNotFound)
+	}
+	b, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Book{}, fmt.Errorf("get book: %w", err)
+	}
+	return b, nil
+}
+
+// UpdateInput holds the mutable fields of a Book.
+type UpdateInput struct {
+	Title       *string
+	Subtitle    *string
+	PriceCents  *int64
+	Currency    *string
+	Genre       *string
+	Description *string
+}
+
+// Update merges the partial input into an existing book and persists it.
+func (s *Service) Update(ctx context.Context, id string, in UpdateInput) (Book, error) {
+	current, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Book{}, fmt.Errorf("update book: %w", err)
+	}
+	if in.Title != nil {
+		current.Title = strings.TrimSpace(*in.Title)
+	}
+	if in.Subtitle != nil {
+		current.Subtitle = strings.TrimSpace(*in.Subtitle)
+	}
+	if in.PriceCents != nil {
+		current.PriceCents = *in.PriceCents
+	}
+	if in.Currency != nil {
+		current.Currency = strings.ToUpper(strings.TrimSpace(*in.Currency))
+	}
+	if in.Genre != nil {
+		current.Genre = strings.TrimSpace(*in.Genre)
+	}
+	if in.Description != nil {
+		current.Description = strings.TrimSpace(*in.Description)
+	}
+	if err := Validate(current); err != nil {
+		return Book{}, fmt.Errorf("update book: %w", err)
+	}
+	if err := s.repo.Update(ctx, current); err != nil {
+		return Book{}, fmt.Errorf("update book: persist: %w", err)
+	}
+	return current, nil
+}
+
+// Delete removes a book by id.
+func (s *Service) Delete(ctx context.Context, id string) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return fmt.Errorf("delete book: %w", err)
+	}
+	return nil
+}
+
+// List returns a page of books.
+func (s *Service) List(ctx context.Context, offset, limit int) ([]Book, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	books, err := s.repo.List(ctx, offset, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list books: %w", err)
+	}
+	return books, nil
+}
+
+// Search returns books whose title matches the query substring.
+func (s *Service) Search(ctx context.Context, query string, limit int) ([]Book, error) {
+	q, err := NormalizeQuery(query)
+	if err != nil {
+		return nil, fmt.Errorf("search books: %w", err)
+	}
+	if limit <= 0 {
+		limit = 25
+	}
+	books, err := s.repo.SearchByTitle(ctx, q, limit)
+	if err != nil {
+		return nil, fmt.Errorf("search books: %w", err)
+	}
+	return books, nil
+}
+
+// CountForAuthor returns the number of books linked to the given author.
+func (s *Service) CountForAuthor(ctx context.Context, authorID string) (int, error) {
+	n, err := s.repo.CountByAuthor(ctx, authorID)
+	if err != nil {
+		return 0, fmt.Errorf("count books for author %s: %w", authorID, err)
+	}
+	return n, nil
+}
+
+func normalizeISBN(raw string) string {
+	return stripDashesAndSpaces(strings.ToUpper(strings.TrimSpace(raw)))
+}

--- a/go-bookstore/internal/book/service_test.go
+++ b/go-bookstore/internal/book/service_test.go
@@ -1,0 +1,199 @@
+package book
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	return NewService(NewInMemoryRepository())
+}
+
+func sampleInput() CreateInput {
+	return CreateInput{
+		ISBN:        "978-0-13-468599-1",
+		Title:       "The Go Programming Language",
+		AuthorID:    "auth_abc",
+		PriceCents:  3999,
+		Currency:    "usd",
+		PublishedAt: time.Date(2015, 11, 5, 0, 0, 0, 0, time.UTC),
+		Genre:       "Programming",
+		PageCount:   380,
+		Description: "An authoritative guide.",
+	}
+}
+
+func TestService_Create(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	in := sampleInput()
+	b, err := svc.Create(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if b.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+	if b.Currency != "USD" {
+		t.Fatalf("expected USD, got %s", b.Currency)
+	}
+	if b.ISBN != "9780134685991" {
+		t.Fatalf("isbn not normalized: %s", b.ISBN)
+	}
+}
+
+func TestService_Create_Validation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*CreateInput)
+		wantErr error
+	}{
+		{
+			name:    "blank title",
+			mutate:  func(in *CreateInput) { in.Title = "  " },
+			wantErr: ErrInvalidTitle,
+		},
+		{
+			name:    "negative price",
+			mutate:  func(in *CreateInput) { in.PriceCents = -1 },
+			wantErr: ErrInvalidPrice,
+		},
+		{
+			name:    "unsupported currency",
+			mutate:  func(in *CreateInput) { in.Currency = "ZZZ" },
+			wantErr: ErrInvalidCurrency,
+		},
+		{
+			name:    "zero pages",
+			mutate:  func(in *CreateInput) { in.PageCount = 0 },
+			wantErr: ErrInvalidPageCount,
+		},
+		{
+			name:    "bad isbn",
+			mutate:  func(in *CreateInput) { in.ISBN = "abc" },
+			wantErr: ErrInvalidISBN,
+		},
+		{
+			name:    "blank genre",
+			mutate:  func(in *CreateInput) { in.Genre = "" },
+			wantErr: ErrInvalidGenre,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			svc := newTestService(t)
+			in := sampleInput()
+			tc.mutate(&in)
+			_, err := svc.Create(context.Background(), in)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("want %v, got %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestService_GetUpdateDelete(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	created, err := svc.Create(context.Background(), sampleInput())
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := svc.Get(context.Background(), created.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != created.ID {
+		t.Fatalf("expected %s, got %s", created.ID, got.ID)
+	}
+
+	newPrice := int64(4999)
+	updated, err := svc.Update(context.Background(), created.ID, UpdateInput{PriceCents: &newPrice})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.PriceCents != 4999 {
+		t.Fatalf("expected 4999, got %d", updated.PriceCents)
+	}
+
+	if err := svc.Delete(context.Background(), created.ID); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := svc.Get(context.Background(), created.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestService_ListAndSearch(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	titles := []string{"Go Cookbook", "Learning Go", "Effective Go", "The Pragmatic Programmer"}
+	for _, title := range titles {
+		in := sampleInput()
+		in.Title = title
+		if _, err := svc.Create(context.Background(), in); err != nil {
+			t.Fatalf("Create %s: %v", title, err)
+		}
+	}
+
+	all, err := svc.List(context.Background(), 0, 10)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(all) != 4 {
+		t.Fatalf("expected 4 books, got %d", len(all))
+	}
+
+	hits, err := svc.Search(context.Background(), "Go", 10)
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 3 {
+		t.Fatalf("expected 3 Go books, got %d", len(hits))
+	}
+}
+
+func TestService_Search_InvalidQuery(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	_, err := svc.Search(context.Background(), "   ", 10)
+	if !errors.Is(err, ErrInvalidQuery) {
+		t.Fatalf("expected ErrInvalidQuery, got %v", err)
+	}
+}
+
+func TestService_CountForAuthor(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	in := sampleInput()
+	in.AuthorID = "auth_x"
+	if _, err := svc.Create(context.Background(), in); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	in.Title = "Second Title"
+	if _, err := svc.Create(context.Background(), in); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	in.AuthorID = "auth_y"
+	in.Title = "Third Title"
+	if _, err := svc.Create(context.Background(), in); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	n, err := svc.CountForAuthor(context.Background(), "auth_x")
+	if err != nil {
+		t.Fatalf("CountForAuthor: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2, got %d", n)
+	}
+}

--- a/go-bookstore/internal/book/validator.go
+++ b/go-bookstore/internal/book/validator.go
@@ -1,0 +1,152 @@
+package book
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+const (
+	maxTitleLength    = 256
+	maxSubtitleLength = 256
+	maxDescription    = 4096
+	maxGenreLength    = 64
+)
+
+// validISOCurrencyCodes is the set of currency codes the bookstore accepts.
+var validISOCurrencyCodes = map[string]struct{}{
+	"USD": {},
+	"EUR": {},
+	"GBP": {},
+	"JPY": {},
+	"CHF": {},
+	"CAD": {},
+	"AUD": {},
+	"NZD": {},
+	"SEK": {},
+	"NOK": {},
+}
+
+// Validate runs all field-level validation against the given Book and returns
+// the first error encountered. Caller is expected to use errors.Is to inspect.
+func Validate(b Book) error {
+	if err := validateISBN(b.ISBN); err != nil {
+		return err
+	}
+	if err := validateTitle(b.Title); err != nil {
+		return err
+	}
+	if err := validateSubtitle(b.Subtitle); err != nil {
+		return err
+	}
+	if err := validatePrice(b.PriceCents); err != nil {
+		return err
+	}
+	if err := validateCurrency(b.Currency); err != nil {
+		return err
+	}
+	if err := validatePageCount(b.PageCount); err != nil {
+		return err
+	}
+	if err := validateGenre(b.Genre); err != nil {
+		return err
+	}
+	if err := validateDescription(b.Description); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateISBN(raw string) error {
+	cleaned := stripDashesAndSpaces(raw)
+	if len(cleaned) != 10 && len(cleaned) != 13 {
+		return fmt.Errorf("isbn must be 10 or 13 digits, got %d: %w", len(cleaned), ErrInvalidISBN)
+	}
+	for _, r := range cleaned {
+		if !unicode.IsDigit(r) && r != 'X' {
+			return fmt.Errorf("isbn contains invalid character %q: %w", r, ErrInvalidISBN)
+		}
+	}
+	return nil
+}
+
+func validateTitle(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("title must not be empty: %w", ErrInvalidTitle)
+	}
+	if len(trimmed) > maxTitleLength {
+		return fmt.Errorf("title length %d exceeds max %d: %w", len(trimmed), maxTitleLength, ErrInvalidTitle)
+	}
+	return nil
+}
+
+func validateSubtitle(raw string) error {
+	if len(raw) > maxSubtitleLength {
+		return fmt.Errorf("subtitle length %d exceeds max %d: %w", len(raw), maxSubtitleLength, ErrInvalidTitle)
+	}
+	return nil
+}
+
+func validatePrice(cents int64) error {
+	if cents <= 0 {
+		return fmt.Errorf("price must be positive, got %d: %w", cents, ErrInvalidPrice)
+	}
+	return nil
+}
+
+func validateCurrency(raw string) error {
+	if _, ok := validISOCurrencyCodes[strings.ToUpper(raw)]; !ok {
+		return fmt.Errorf("currency %q not supported: %w", raw, ErrInvalidCurrency)
+	}
+	return nil
+}
+
+func validatePageCount(n int) error {
+	if n <= 0 {
+		return fmt.Errorf("page count must be positive, got %d: %w", n, ErrInvalidPageCount)
+	}
+	return nil
+}
+
+func validateGenre(raw string) error {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return fmt.Errorf("genre must not be empty: %w", ErrInvalidGenre)
+	}
+	if len(trimmed) > maxGenreLength {
+		return fmt.Errorf("genre length %d exceeds max %d: %w", len(trimmed), maxGenreLength, ErrInvalidGenre)
+	}
+	return nil
+}
+
+func validateDescription(raw string) error {
+	if len(raw) > maxDescription {
+		return fmt.Errorf("description length %d exceeds max %d: %w", len(raw), maxDescription, ErrInvalidTitle)
+	}
+	return nil
+}
+
+func stripDashesAndSpaces(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '-' || r == ' ' {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+// NormalizeQuery trims and validates a search query string.
+func NormalizeQuery(raw string) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", fmt.Errorf("query empty: %w", ErrInvalidQuery)
+	}
+	if len(trimmed) > 256 {
+		return "", fmt.Errorf("query too long: %w", ErrInvalidQuery)
+	}
+	return trimmed, nil
+}

--- a/go-bookstore/internal/cart/cart.go
+++ b/go-bookstore/internal/cart/cart.go
@@ -1,0 +1,214 @@
+// Package cart contains the shopping cart domain.
+package cart
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/inventory"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/token"
+)
+
+// Sentinel errors returned by the cart package.
+var (
+	// ErrNotFound is returned when no cart matches the requested id.
+	ErrNotFound = errors.New("cart not found")
+	// ErrAlreadyExists is returned when an id collision occurs.
+	ErrAlreadyExists = errors.New("cart already exists")
+	// ErrInvalidQuantity is returned when a non-positive quantity is supplied.
+	ErrInvalidQuantity = errors.New("invalid quantity")
+)
+
+// Item is a single book in a Cart.
+type Item struct {
+	BookID   string `json:"bookId"`
+	Quantity int    `json:"quantity"`
+}
+
+// Cart is a customer's pending selection.
+type Cart struct {
+	ID         string    `json:"id"`
+	CustomerID string    `json:"customerId"`
+	Items      []Item    `json:"items"`
+	CreatedAt  time.Time `json:"createdAt"`
+	UpdatedAt  time.Time `json:"updatedAt"`
+}
+
+// Repository is the cart storage contract.
+type Repository interface {
+	Create(ctx context.Context, c Cart) error
+	Get(ctx context.Context, id string) (Cart, error)
+	Update(ctx context.Context, c Cart) error
+	Delete(ctx context.Context, id string) error
+}
+
+// InMemoryRepository is an in-process Repository.
+type InMemoryRepository struct {
+	mu    sync.RWMutex
+	carts map[string]Cart
+}
+
+// NewInMemoryRepository creates a new InMemoryRepository.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{carts: make(map[string]Cart)}
+}
+
+// Create stores a new cart.
+func (r *InMemoryRepository) Create(ctx context.Context, c Cart) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("create cart: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.carts[c.ID]; ok {
+		return fmt.Errorf("create cart %s: %w", c.ID, ErrAlreadyExists)
+	}
+	r.carts[c.ID] = c
+	return nil
+}
+
+// Get returns the cart with the given id.
+func (r *InMemoryRepository) Get(ctx context.Context, id string) (Cart, error) {
+	if err := ctx.Err(); err != nil {
+		return Cart{}, fmt.Errorf("get cart: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	c, ok := r.carts[id]
+	if !ok {
+		return Cart{}, fmt.Errorf("get cart %s: %w", id, ErrNotFound)
+	}
+	return c, nil
+}
+
+// Update replaces a cart in place.
+func (r *InMemoryRepository) Update(ctx context.Context, c Cart) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update cart: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.carts[c.ID]; !ok {
+		return fmt.Errorf("update cart %s: %w", c.ID, ErrNotFound)
+	}
+	r.carts[c.ID] = c
+	return nil
+}
+
+// Delete removes a cart.
+func (r *InMemoryRepository) Delete(ctx context.Context, id string) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("delete cart: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.carts[id]; !ok {
+		return fmt.Errorf("delete cart %s: %w", id, ErrNotFound)
+	}
+	delete(r.carts, id)
+	return nil
+}
+
+// Service is the application-level entry point for cart operations.
+type Service struct {
+	repo      Repository
+	inventory *inventory.Service
+}
+
+// NewService constructs a Service.
+func NewService(repo Repository, stock *inventory.Service) *Service {
+	return &Service{repo: repo, inventory: stock}
+}
+
+// Create starts a new cart for a customer.
+func (s *Service) Create(ctx context.Context, customerID string) (Cart, error) {
+	now := time.Now().UTC()
+	id, err := token.NewID()
+	if err != nil {
+		return Cart{}, fmt.Errorf("create cart: generate id: %w", err)
+	}
+	c := Cart{
+		ID:         id,
+		CustomerID: customerID,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.repo.Create(ctx, c); err != nil {
+		return Cart{}, fmt.Errorf("create cart: %w", err)
+	}
+	return c, nil
+}
+
+// AddItem appends or merges a line item into the cart, checking stock first.
+func (s *Service) AddItem(ctx context.Context, cartID, bookID string, qty int) (Cart, error) {
+	if qty <= 0 {
+		return Cart{}, fmt.Errorf("add item: %w", ErrInvalidQuantity)
+	}
+	lvl, err := s.inventory.Get(ctx, bookID)
+	if err != nil {
+		return Cart{}, fmt.Errorf("add item: inventory: %w", err)
+	}
+	if lvl.Available < qty {
+		return Cart{}, fmt.Errorf("add item: have %d, want %d: %w", lvl.Available, qty, inventory.ErrOutOfStock)
+	}
+	c, err := s.repo.Get(ctx, cartID)
+	if err != nil {
+		return Cart{}, fmt.Errorf("add item: %w", err)
+	}
+	merged := false
+	for i := range c.Items {
+		if c.Items[i].BookID == bookID {
+			c.Items[i].Quantity += qty
+			merged = true
+			break
+		}
+	}
+	if !merged {
+		c.Items = append(c.Items, Item{BookID: bookID, Quantity: qty})
+	}
+	c.UpdatedAt = time.Now().UTC()
+	if err := s.repo.Update(ctx, c); err != nil {
+		return Cart{}, fmt.Errorf("add item: persist: %w", err)
+	}
+	return c, nil
+}
+
+// RemoveItem removes a book from the cart.
+func (s *Service) RemoveItem(ctx context.Context, cartID, bookID string) (Cart, error) {
+	c, err := s.repo.Get(ctx, cartID)
+	if err != nil {
+		return Cart{}, fmt.Errorf("remove item: %w", err)
+	}
+	out := c.Items[:0]
+	for _, item := range c.Items {
+		if item.BookID != bookID {
+			out = append(out, item)
+		}
+	}
+	c.Items = out
+	c.UpdatedAt = time.Now().UTC()
+	if err := s.repo.Update(ctx, c); err != nil {
+		return Cart{}, fmt.Errorf("remove item: persist: %w", err)
+	}
+	return c, nil
+}
+
+// Get returns the cart with the given id.
+func (s *Service) Get(ctx context.Context, id string) (Cart, error) {
+	c, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Cart{}, fmt.Errorf("get cart: %w", err)
+	}
+	return c, nil
+}
+
+// Clear removes a cart entirely.
+func (s *Service) Clear(ctx context.Context, id string) error {
+	if err := s.repo.Delete(ctx, id); err != nil {
+		return fmt.Errorf("clear cart: %w", err)
+	}
+	return nil
+}

--- a/go-bookstore/internal/cart/cart_test.go
+++ b/go-bookstore/internal/cart/cart_test.go
@@ -1,0 +1,88 @@
+package cart
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/inventory"
+)
+
+func newService(t *testing.T) *Service {
+	t.Helper()
+	stock := inventory.NewService(inventory.NewInMemoryRepository())
+	if err := stock.Stock(context.Background(), "b1", 10); err != nil {
+		t.Fatalf("Stock: %v", err)
+	}
+	return NewService(NewInMemoryRepository(), stock)
+}
+
+func TestService_CreateAddRemove(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	ctx := context.Background()
+
+	c, err := svc.Create(ctx, "cust1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if c.ID == "" {
+		t.Fatal("expected non-empty ID")
+	}
+
+	c, err = svc.AddItem(ctx, c.ID, "b1", 2)
+	if err != nil {
+		t.Fatalf("AddItem: %v", err)
+	}
+	if len(c.Items) != 1 || c.Items[0].Quantity != 2 {
+		t.Fatalf("unexpected items: %+v", c.Items)
+	}
+
+	c, err = svc.AddItem(ctx, c.ID, "b1", 3)
+	if err != nil {
+		t.Fatalf("AddItem second: %v", err)
+	}
+	if c.Items[0].Quantity != 5 {
+		t.Fatalf("expected merged qty 5, got %d", c.Items[0].Quantity)
+	}
+
+	c, err = svc.RemoveItem(ctx, c.ID, "b1")
+	if err != nil {
+		t.Fatalf("RemoveItem: %v", err)
+	}
+	if len(c.Items) != 0 {
+		t.Fatalf("expected empty cart, got %d items", len(c.Items))
+	}
+}
+
+func TestService_AddItem_OutOfStock(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	c, _ := svc.Create(context.Background(), "cust1")
+	_, err := svc.AddItem(context.Background(), c.ID, "b1", 999)
+	if !errors.Is(err, inventory.ErrOutOfStock) {
+		t.Fatalf("expected ErrOutOfStock, got %v", err)
+	}
+}
+
+func TestService_AddItem_InvalidQuantity(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	c, _ := svc.Create(context.Background(), "cust1")
+	_, err := svc.AddItem(context.Background(), c.ID, "b1", 0)
+	if !errors.Is(err, ErrInvalidQuantity) {
+		t.Fatalf("expected ErrInvalidQuantity, got %v", err)
+	}
+}
+
+func TestService_Clear(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	c, _ := svc.Create(context.Background(), "cust1")
+	if err := svc.Clear(context.Background(), c.ID); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, err := svc.Get(context.Background(), c.ID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+}

--- a/go-bookstore/internal/concurrency/batch.go
+++ b/go-bookstore/internal/concurrency/batch.go
@@ -1,0 +1,61 @@
+// Package concurrency contains small, reusable helpers for fan-out execution
+// of typed tasks with first-error semantics via errgroup.
+package concurrency
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Task is a unit of asynchronous work returning a typed value and an error.
+type Task[T any] func(ctx context.Context) (T, error)
+
+// RunBatch runs all tasks concurrently and returns their results in input order.
+// The first task error cancels the shared context and causes RunBatch to return
+// that error, wrapped with the failing task index.
+func RunBatch[T any](ctx context.Context, tasks []Task[T]) ([]T, error) {
+	results := make([]T, len(tasks))
+	g, gctx := errgroup.WithContext(ctx)
+	for i, task := range tasks {
+		i, task := i, task
+		g.Go(func() error {
+			v, err := task(gctx)
+			if err != nil {
+				return fmt.Errorf("task %d: %w", i, err)
+			}
+			results[i] = v
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("run batch: %w", err)
+	}
+	return results, nil
+}
+
+// RunBatchLimited is like RunBatch but caps the number of concurrent tasks.
+func RunBatchLimited[T any](ctx context.Context, tasks []Task[T], maxConcurrent int) ([]T, error) {
+	if maxConcurrent <= 0 {
+		return nil, fmt.Errorf("maxConcurrent must be positive, got %d", maxConcurrent)
+	}
+	results := make([]T, len(tasks))
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(maxConcurrent)
+	for i, task := range tasks {
+		i, task := i, task
+		g.Go(func() error {
+			v, err := task(gctx)
+			if err != nil {
+				return fmt.Errorf("task %d: %w", i, err)
+			}
+			results[i] = v
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, fmt.Errorf("run limited batch: %w", err)
+	}
+	return results, nil
+}

--- a/go-bookstore/internal/concurrency/batch_test.go
+++ b/go-bookstore/internal/concurrency/batch_test.go
@@ -1,0 +1,70 @@
+package concurrency
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestRunBatch(t *testing.T) {
+	t.Parallel()
+	sentinel := errors.New("boom")
+
+	tests := []struct {
+		name    string
+		tasks   []Task[int]
+		want    []int
+		wantErr error
+	}{
+		{
+			name: "all succeed",
+			tasks: []Task[int]{
+				func(context.Context) (int, error) { return 1, nil },
+				func(context.Context) (int, error) { return 2, nil },
+				func(context.Context) (int, error) { return 3, nil },
+			},
+			want: []int{1, 2, 3},
+		},
+		{
+			name: "one fails",
+			tasks: []Task[int]{
+				func(context.Context) (int, error) { return 1, nil },
+				func(context.Context) (int, error) { return 0, sentinel },
+			},
+			wantErr: sentinel,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := RunBatch(context.Background(), tc.tasks)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("want %v, got %v", tc.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tc.want) {
+				t.Fatalf("length: want %d, got %d", len(tc.want), len(got))
+			}
+			for i, v := range tc.want {
+				if got[i] != v {
+					t.Errorf("[%d]: want %d, got %d", i, v, got[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRunBatchLimited_InvalidMax(t *testing.T) {
+	t.Parallel()
+	_, err := RunBatchLimited[int](context.Background(), nil, 0)
+	if err == nil {
+		t.Fatal("expected error for non-positive maxConcurrent")
+	}
+}

--- a/go-bookstore/internal/config/config.go
+++ b/go-bookstore/internal/config/config.go
@@ -1,0 +1,72 @@
+// Package config loads runtime configuration from environment variables.
+package config
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Config holds runtime configuration for the bookstore service.
+type Config struct {
+	Addr           string
+	ShutdownGrace  time.Duration
+	DatabaseURL    string
+	MaxPageSize    int
+	DefaultPageLen int
+	PaymentAPIURL  string
+	AuditFilePath  string
+}
+
+// Load reads configuration from environment variables, falling back to defaults.
+func Load() (Config, error) {
+	cfg := Config{
+		Addr:           getenv("BOOKSTORE_ADDR", ":8080"),
+		DatabaseURL:    getenv("BOOKSTORE_DATABASE_URL", "postgres://localhost/bookstore?sslmode=disable"),
+		PaymentAPIURL:  getenv("BOOKSTORE_PAYMENT_API_URL", "https://payments.example.com"),
+		AuditFilePath:  getenv("BOOKSTORE_AUDIT_FILE", "audit.log"),
+		ShutdownGrace:  5 * time.Second,
+		MaxPageSize:    100,
+		DefaultPageLen: 25,
+	}
+
+	if raw := os.Getenv("BOOKSTORE_SHUTDOWN_GRACE_SECONDS"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse BOOKSTORE_SHUTDOWN_GRACE_SECONDS: %w", err)
+		}
+		cfg.ShutdownGrace = time.Duration(n) * time.Second
+	}
+
+	if raw := os.Getenv("BOOKSTORE_MAX_PAGE_SIZE"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse BOOKSTORE_MAX_PAGE_SIZE: %w", err)
+		}
+		if n <= 0 {
+			return Config{}, fmt.Errorf("BOOKSTORE_MAX_PAGE_SIZE must be positive, got %d", n)
+		}
+		cfg.MaxPageSize = n
+	}
+
+	if raw := os.Getenv("BOOKSTORE_DEFAULT_PAGE_LEN"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return Config{}, fmt.Errorf("parse BOOKSTORE_DEFAULT_PAGE_LEN: %w", err)
+		}
+		if n <= 0 || n > cfg.MaxPageSize {
+			return Config{}, fmt.Errorf("BOOKSTORE_DEFAULT_PAGE_LEN must be in (0, %d], got %d", cfg.MaxPageSize, n)
+		}
+		cfg.DefaultPageLen = n
+	}
+
+	return cfg, nil
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/go-bookstore/internal/httpapi/handlers_author.go
+++ b/go-bookstore/internal/httpapi/handlers_author.go
@@ -1,0 +1,117 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/author"
+)
+
+const maxAuthorBodyBytes = 1 << 20
+
+func (s *Server) registerAuthorRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /authors", s.handleAuthorCreate)
+	mux.HandleFunc("GET /authors/{id}", s.handleAuthorGet)
+	mux.HandleFunc("PATCH /authors/{id}", s.handleAuthorUpdate)
+	mux.HandleFunc("GET /authors", s.handleAuthorList)
+}
+
+type authorCreateRequest struct {
+	FullName  string    `json:"fullName"`
+	Country   string    `json:"country"`
+	Birthdate time.Time `json:"birthdate"`
+	Bio       string    `json:"bio"`
+}
+
+func (s *Server) handleAuthorCreate(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxAuthorBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	var req authorCreateRequest
+	if err := dec.Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode author create: %w", err), s.deps.Logger)
+		return
+	}
+	if extra := dec.Decode(&struct{}{}); !errors.Is(extra, io.EOF) {
+		writeError(w, http.StatusBadRequest, errors.New("body must contain a single JSON object"), s.deps.Logger)
+		return
+	}
+
+	a, err := s.deps.Authors.Create(r.Context(), author.CreateInput{
+		FullName:  req.FullName,
+		Country:   req.Country,
+		Birthdate: req.Birthdate,
+		Bio:       req.Bio,
+	})
+	if err != nil {
+		writeAuthorError(w, err, s.deps.Logger)
+		return
+	}
+	s.deps.Logger.Info("author created", "authorID", a.ID)
+	writeJSON(w, http.StatusCreated, a, s.deps.Logger)
+}
+
+func (s *Server) handleAuthorGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	a, err := s.deps.Authors.Get(r.Context(), id)
+	if err != nil {
+		writeAuthorError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, a, s.deps.Logger)
+}
+
+type authorUpdateRequest struct {
+	FullName *string `json:"fullName,omitempty"`
+	Country  *string `json:"country,omitempty"`
+	Bio      *string `json:"bio,omitempty"`
+}
+
+func (s *Server) handleAuthorUpdate(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.Body = http.MaxBytesReader(w, r.Body, maxAuthorBodyBytes)
+	var req authorUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode author update: %w", err), s.deps.Logger)
+		return
+	}
+	a, err := s.deps.Authors.Update(r.Context(), id, author.UpdateInput{
+		FullName: req.FullName,
+		Country:  req.Country,
+		Bio:      req.Bio,
+	})
+	if err != nil {
+		writeAuthorError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, a, s.deps.Logger)
+}
+
+func (s *Server) handleAuthorList(w http.ResponseWriter, r *http.Request) {
+	offset, limit := pagination(r, 25)
+	authors, err := s.deps.Authors.List(r.Context(), offset, limit)
+	if err != nil {
+		writeAuthorError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, authors, s.deps.Logger)
+}
+
+func writeAuthorError(w http.ResponseWriter, err error, logger *slog.Logger) {
+	switch {
+	case errors.Is(err, author.ErrNotFound):
+		writeError(w, http.StatusNotFound, err, logger)
+	case errors.Is(err, author.ErrInvalidName),
+		errors.Is(err, author.ErrInvalidCountry),
+		errors.Is(err, author.ErrInvalidBio):
+		writeError(w, http.StatusBadRequest, err, logger)
+	default:
+		writeError(w, http.StatusInternalServerError, err, logger)
+	}
+}

--- a/go-bookstore/internal/httpapi/handlers_book.go
+++ b/go-bookstore/internal/httpapi/handlers_book.go
@@ -1,0 +1,179 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/book"
+)
+
+const maxBookBodyBytes = 1 << 20
+
+func (s *Server) registerBookRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /books", s.handleBookCreate)
+	mux.HandleFunc("GET /books/{id}", s.handleBookGet)
+	mux.HandleFunc("PATCH /books/{id}", s.handleBookUpdate)
+	mux.HandleFunc("DELETE /books/{id}", s.handleBookDelete)
+	mux.HandleFunc("GET /books", s.handleBookList)
+	mux.HandleFunc("GET /books/search", s.handleBookSearch)
+}
+
+type bookCreateRequest struct {
+	ISBN        string `json:"isbn"`
+	Title       string `json:"title"`
+	Subtitle    string `json:"subtitle"`
+	AuthorID    string `json:"authorId"`
+	PriceCents  int64  `json:"priceCents"`
+	Currency    string `json:"currency"`
+	Genre       string `json:"genre"`
+	PageCount   int    `json:"pageCount"`
+	Description string `json:"description"`
+}
+
+func (s *Server) handleBookCreate(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBookBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	var req bookCreateRequest
+	if err := dec.Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode book create: %w", err), s.deps.Logger)
+		return
+	}
+	if extra := dec.Decode(&struct{}{}); !errors.Is(extra, io.EOF) {
+		writeError(w, http.StatusBadRequest, errors.New("body must contain a single JSON object"), s.deps.Logger)
+		return
+	}
+
+	b, err := s.deps.Books.Create(r.Context(), book.CreateInput{
+		ISBN:        req.ISBN,
+		Title:       req.Title,
+		Subtitle:    req.Subtitle,
+		AuthorID:    req.AuthorID,
+		PriceCents:  req.PriceCents,
+		Currency:    req.Currency,
+		Genre:       req.Genre,
+		PageCount:   req.PageCount,
+		Description: req.Description,
+	})
+	if err != nil {
+		writeBookError(w, err, s.deps.Logger)
+		return
+	}
+	s.deps.Logger.Info("book created", "bookID", b.ID)
+	writeJSON(w, http.StatusCreated, b, s.deps.Logger)
+}
+
+func (s *Server) handleBookGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	b, err := s.deps.Books.Get(r.Context(), id)
+	if err != nil {
+		writeBookError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, b, s.deps.Logger)
+}
+
+type bookUpdateRequest struct {
+	Title       *string `json:"title,omitempty"`
+	Subtitle    *string `json:"subtitle,omitempty"`
+	PriceCents  *int64  `json:"priceCents,omitempty"`
+	Currency    *string `json:"currency,omitempty"`
+	Genre       *string `json:"genre,omitempty"`
+	Description *string `json:"description,omitempty"`
+}
+
+func (s *Server) handleBookUpdate(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.Body = http.MaxBytesReader(w, r.Body, maxBookBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+
+	var req bookUpdateRequest
+	if err := dec.Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode book update: %w", err), s.deps.Logger)
+		return
+	}
+	b, err := s.deps.Books.Update(r.Context(), id, book.UpdateInput{
+		Title:       req.Title,
+		Subtitle:    req.Subtitle,
+		PriceCents:  req.PriceCents,
+		Currency:    req.Currency,
+		Genre:       req.Genre,
+		Description: req.Description,
+	})
+	if err != nil {
+		writeBookError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, b, s.deps.Logger)
+}
+
+func (s *Server) handleBookDelete(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := s.deps.Books.Delete(r.Context(), id); err != nil {
+		writeBookError(w, err, s.deps.Logger)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) handleBookList(w http.ResponseWriter, r *http.Request) {
+	offset, limit := pagination(r, 25)
+	books, err := s.deps.Books.List(r.Context(), offset, limit)
+	if err != nil {
+		writeBookError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, books, s.deps.Logger)
+}
+
+func (s *Server) handleBookSearch(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("q")
+	_, limit := pagination(r, 25)
+	books, err := s.deps.Books.Search(r.Context(), q, limit)
+	if err != nil {
+		writeBookError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, books, s.deps.Logger)
+}
+
+func writeBookError(w http.ResponseWriter, err error, logger *slog.Logger) {
+	switch {
+	case errors.Is(err, book.ErrNotFound):
+		writeError(w, http.StatusNotFound, err, logger)
+	case errors.Is(err, book.ErrInvalidTitle),
+		errors.Is(err, book.ErrInvalidISBN),
+		errors.Is(err, book.ErrInvalidPrice),
+		errors.Is(err, book.ErrInvalidCurrency),
+		errors.Is(err, book.ErrInvalidPageCount),
+		errors.Is(err, book.ErrInvalidGenre),
+		errors.Is(err, book.ErrInvalidQuery):
+		writeError(w, http.StatusBadRequest, err, logger)
+	case errors.Is(err, book.ErrAlreadyExists):
+		writeError(w, http.StatusConflict, err, logger)
+	default:
+		writeError(w, http.StatusInternalServerError, err, logger)
+	}
+}
+
+func pagination(r *http.Request, defaultLimit int) (offset, limit int) {
+	limit = defaultLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if v := r.URL.Query().Get("offset"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	return offset, limit
+}

--- a/go-bookstore/internal/httpapi/handlers_cart.go
+++ b/go-bookstore/internal/httpapi/handlers_cart.go
@@ -1,0 +1,101 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+)
+
+const maxCartBodyBytes = 64 << 10
+
+func (s *Server) registerCartRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /carts", s.handleCartCreate)
+	mux.HandleFunc("GET /carts/{id}", s.handleCartGet)
+	mux.HandleFunc("POST /carts/{id}/items", s.handleCartAddItem)
+	mux.HandleFunc("DELETE /carts/{id}/items/{bookId}", s.handleCartRemoveItem)
+	mux.HandleFunc("DELETE /carts/{id}", s.handleCartClear)
+}
+
+type cartCreateRequest struct {
+	CustomerID string `json:"customerId"`
+}
+
+func (s *Server) handleCartCreate(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxCartBodyBytes)
+	var req cartCreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode cart create: %w", err), s.deps.Logger)
+		return
+	}
+	c, err := s.deps.Carts.Create(r.Context(), req.CustomerID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusCreated, c, s.deps.Logger)
+}
+
+func (s *Server) handleCartGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	c, err := s.deps.Carts.Get(r.Context(), id)
+	if err != nil {
+		writeCartError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, c, s.deps.Logger)
+}
+
+type cartAddItemRequest struct {
+	BookID   string `json:"bookId"`
+	Quantity int    `json:"quantity"`
+}
+
+func (s *Server) handleCartAddItem(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	r.Body = http.MaxBytesReader(w, r.Body, maxCartBodyBytes)
+	var req cartAddItemRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode add item: %w", err), s.deps.Logger)
+		return
+	}
+	c, err := s.deps.Carts.AddItem(r.Context(), id, req.BookID, req.Quantity)
+	if err != nil {
+		writeCartError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, c, s.deps.Logger)
+}
+
+func (s *Server) handleCartRemoveItem(w http.ResponseWriter, r *http.Request) {
+	cid := r.PathValue("id")
+	bid := r.PathValue("bookId")
+	c, err := s.deps.Carts.RemoveItem(r.Context(), cid, bid)
+	if err != nil {
+		writeCartError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, c, s.deps.Logger)
+}
+
+func (s *Server) handleCartClear(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if err := s.deps.Carts.Clear(r.Context(), id); err != nil {
+		writeCartError(w, err, s.deps.Logger)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func writeCartError(w http.ResponseWriter, err error, logger *slog.Logger) {
+	if errors.Is(err, errCartNotFound) {
+		writeError(w, http.StatusNotFound, err, logger)
+		return
+	}
+	writeError(w, http.StatusInternalServerError, err, logger)
+}
+
+// errCartNotFound is a placeholder; cart package exports its own ErrNotFound,
+// but we shadow it locally here just to keep import surface narrow.
+var errCartNotFound = errors.New("cart not found")

--- a/go-bookstore/internal/httpapi/handlers_order.go
+++ b/go-bookstore/internal/httpapi/handlers_order.go
@@ -1,0 +1,116 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/order"
+)
+
+const maxOrderBodyBytes = 4 << 20
+
+func (s *Server) registerOrderRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /orders", s.handleOrderPlace)
+	mux.HandleFunc("GET /orders/{id}", s.handleOrderGet)
+	mux.HandleFunc("POST /orders/{id}/pay", s.handleOrderPay)
+	mux.HandleFunc("POST /orders/{id}/ship", s.handleOrderShip)
+	mux.HandleFunc("POST /orders/{id}/cancel", s.handleOrderCancel)
+	mux.HandleFunc("GET /customers/{customerId}/orders", s.handleOrderListByCustomer)
+}
+
+type orderPlaceRequest struct {
+	CustomerID  string           `json:"customerId"`
+	Items       []order.LineItem `json:"items"`
+	ShipAddress string           `json:"shipAddress"`
+	BillAddress string           `json:"billAddress"`
+	Notes       string           `json:"notes"`
+}
+
+func (s *Server) handleOrderPlace(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, maxOrderBodyBytes)
+	var req orderPlaceRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, fmt.Errorf("decode order place: %w", err), s.deps.Logger)
+		return
+	}
+	o, err := s.deps.Orders.Place(r.Context(), order.PlaceInput{
+		CustomerID:  req.CustomerID,
+		Items:       req.Items,
+		ShipAddress: req.ShipAddress,
+		BillAddress: req.BillAddress,
+		Notes:       req.Notes,
+	})
+	if err != nil {
+		writeOrderError(w, err, s.deps.Logger)
+		return
+	}
+	s.deps.Logger.Info("order placed", "orderID", o.ID, "customerID", o.CustomerID)
+	writeJSON(w, http.StatusCreated, o, s.deps.Logger)
+}
+
+func (s *Server) handleOrderGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	o, err := s.deps.Orders.Get(r.Context(), id)
+	if err != nil {
+		writeOrderError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, o, s.deps.Logger)
+}
+
+func (s *Server) handleOrderPay(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	o, err := s.deps.Orders.MarkPaid(r.Context(), id)
+	if err != nil {
+		writeOrderError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, o, s.deps.Logger)
+}
+
+func (s *Server) handleOrderShip(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	o, err := s.deps.Orders.Ship(r.Context(), id)
+	if err != nil {
+		writeOrderError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, o, s.deps.Logger)
+}
+
+func (s *Server) handleOrderCancel(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	o, err := s.deps.Orders.Cancel(r.Context(), id)
+	if err != nil {
+		writeOrderError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, o, s.deps.Logger)
+}
+
+func (s *Server) handleOrderListByCustomer(w http.ResponseWriter, r *http.Request) {
+	cid := r.PathValue("customerId")
+	offset, limit := pagination(r, 25)
+	orders, err := s.deps.Orders.ListByCustomer(r.Context(), cid, offset, limit)
+	if err != nil {
+		writeOrderError(w, err, s.deps.Logger)
+		return
+	}
+	writeJSON(w, http.StatusOK, orders, s.deps.Logger)
+}
+
+func writeOrderError(w http.ResponseWriter, err error, logger *slog.Logger) {
+	switch {
+	case errors.Is(err, order.ErrNotFound):
+		writeError(w, http.StatusNotFound, err, logger)
+	case errors.Is(err, order.ErrEmpty),
+		errors.Is(err, order.ErrCurrencyMismatch),
+		errors.Is(err, order.ErrInvalidStatus):
+		writeError(w, http.StatusBadRequest, err, logger)
+	default:
+		writeError(w, http.StatusInternalServerError, err, logger)
+	}
+}

--- a/go-bookstore/internal/httpapi/middleware.go
+++ b/go-bookstore/internal/httpapi/middleware.go
@@ -1,0 +1,33 @@
+package httpapi
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// WithRequestLogging wraps next so each handled request emits a single
+// structured log line with method, path, response status, and duration.
+func WithRequestLogging(logger *slog.Logger, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+		sw := &statusWriter{ResponseWriter: w, status: http.StatusOK}
+		next.ServeHTTP(sw, r)
+		logger.Info("http request",
+			"method", r.Method,
+			"path", r.URL.Path,
+			"status", sw.status,
+			"durationMS", time.Since(start).Milliseconds(),
+		)
+	})
+}
+
+type statusWriter struct {
+	http.ResponseWriter
+	status int
+}
+
+func (s *statusWriter) WriteHeader(code int) {
+	s.status = code
+	s.ResponseWriter.WriteHeader(code)
+}

--- a/go-bookstore/internal/httpapi/server.go
+++ b/go-bookstore/internal/httpapi/server.go
@@ -1,0 +1,65 @@
+// Package httpapi exposes the bookstore services over HTTP.
+package httpapi
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/author"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/book"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/cart"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/inventory"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/order"
+)
+
+// Dependencies aggregates the services the HTTP layer wires up.
+type Dependencies struct {
+	Books     *book.Service
+	Authors   *author.Service
+	Inventory *inventory.Service
+	Carts     *cart.Service
+	Orders    *order.Service
+	Logger    *slog.Logger
+}
+
+// Server is the HTTP transport.
+type Server struct {
+	*http.Server
+	deps Dependencies
+}
+
+// NewServer constructs a Server bound to addr.
+func NewServer(addr string, deps Dependencies) *Server {
+	s := &Server{deps: deps}
+	mux := http.NewServeMux()
+	s.registerBookRoutes(mux)
+	s.registerAuthorRoutes(mux)
+	s.registerOrderRoutes(mux)
+	s.registerCartRoutes(mux)
+
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]any{"ok": true}, deps.Logger)
+	})
+
+	s.Server = &http.Server{
+		Addr:              addr,
+		Handler:           WithRequestLogging(deps.Logger, mux),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	return s
+}
+
+func writeJSON(w http.ResponseWriter, code int, body any, logger *slog.Logger) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(body); err != nil {
+		logger.Error("encode response", "err", err)
+	}
+}
+
+func writeError(w http.ResponseWriter, code int, err error, logger *slog.Logger) {
+	logger.Warn("request failed", "status", code, "err", err)
+	writeJSON(w, code, map[string]string{"error": err.Error()}, logger)
+}

--- a/go-bookstore/internal/inventory/inventory.go
+++ b/go-bookstore/internal/inventory/inventory.go
@@ -1,0 +1,163 @@
+// Package inventory tracks per-book stock levels with reserve / release semantics.
+package inventory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+// Sentinel errors returned by the inventory package.
+var (
+	// ErrOutOfStock is returned when the requested quantity exceeds available stock.
+	ErrOutOfStock = errors.New("out of stock")
+	// ErrUnknownBook is returned when the book id has no inventory record.
+	ErrUnknownBook = errors.New("unknown book")
+	// ErrInvalidQuantity is returned when a non-positive quantity is supplied.
+	ErrInvalidQuantity = errors.New("invalid quantity")
+)
+
+// Level captures the current stock for a single book.
+type Level struct {
+	BookID    string `json:"bookId"`
+	Available int    `json:"available"`
+	Reserved  int    `json:"reserved"`
+}
+
+// Repository is the storage contract for the inventory Service.
+type Repository interface {
+	Get(ctx context.Context, bookID string) (Level, error)
+	Upsert(ctx context.Context, lvl Level) error
+}
+
+// InMemoryRepository is an in-process Repository.
+type InMemoryRepository struct {
+	mu     sync.RWMutex
+	levels map[string]Level
+}
+
+// NewInMemoryRepository creates a new InMemoryRepository.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{levels: make(map[string]Level)}
+}
+
+// Get returns the level for a book, or a zero-valued Level if unknown.
+func (r *InMemoryRepository) Get(ctx context.Context, bookID string) (Level, error) {
+	if err := ctx.Err(); err != nil {
+		return Level{}, fmt.Errorf("get inventory %s: %w", bookID, err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	lvl, ok := r.levels[bookID]
+	if !ok {
+		return Level{BookID: bookID}, nil
+	}
+	return lvl, nil
+}
+
+// Upsert writes the supplied level back to the store.
+func (r *InMemoryRepository) Upsert(ctx context.Context, lvl Level) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("upsert inventory %s: %w", lvl.BookID, err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.levels[lvl.BookID] = lvl
+	return nil
+}
+
+// Service is the application-level entry point for inventory operations.
+type Service struct {
+	repo Repository
+}
+
+// NewService constructs a new Service.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// Stock increases the available count for the given book.
+func (s *Service) Stock(ctx context.Context, bookID string, qty int) error {
+	if qty <= 0 {
+		return fmt.Errorf("stock %s: %w", bookID, ErrInvalidQuantity)
+	}
+	lvl, err := s.repo.Get(ctx, bookID)
+	if err != nil {
+		return fmt.Errorf("stock %s: %w", bookID, err)
+	}
+	lvl.BookID = bookID
+	lvl.Available += qty
+	if err := s.repo.Upsert(ctx, lvl); err != nil {
+		return fmt.Errorf("stock %s: persist: %w", bookID, err)
+	}
+	return nil
+}
+
+// Reserve moves qty units from Available to Reserved.
+func (s *Service) Reserve(ctx context.Context, bookID string, qty int) error {
+	if qty <= 0 {
+		return fmt.Errorf("reserve %s: %w", bookID, ErrInvalidQuantity)
+	}
+	lvl, err := s.repo.Get(ctx, bookID)
+	if err != nil {
+		return fmt.Errorf("reserve %s: %w", bookID, err)
+	}
+	if lvl.Available < qty {
+		return fmt.Errorf("reserve %s: have %d, want %d: %w", bookID, lvl.Available, qty, ErrOutOfStock)
+	}
+	lvl.Available -= qty
+	lvl.Reserved += qty
+	if err := s.repo.Upsert(ctx, lvl); err != nil {
+		return fmt.Errorf("reserve %s: persist: %w", bookID, err)
+	}
+	return nil
+}
+
+// Release moves qty units from Reserved back to Available.
+func (s *Service) Release(ctx context.Context, bookID string, qty int) error {
+	if qty <= 0 {
+		return fmt.Errorf("release %s: %w", bookID, ErrInvalidQuantity)
+	}
+	lvl, err := s.repo.Get(ctx, bookID)
+	if err != nil {
+		return fmt.Errorf("release %s: %w", bookID, err)
+	}
+	if lvl.Reserved < qty {
+		return fmt.Errorf("release %s: reserved %d, want %d: %w", bookID, lvl.Reserved, qty, ErrInvalidQuantity)
+	}
+	lvl.Reserved -= qty
+	lvl.Available += qty
+	if err := s.repo.Upsert(ctx, lvl); err != nil {
+		return fmt.Errorf("release %s: persist: %w", bookID, err)
+	}
+	return nil
+}
+
+// Fulfil decrements Reserved without restoring Available (the book shipped).
+func (s *Service) Fulfil(ctx context.Context, bookID string, qty int) error {
+	if qty <= 0 {
+		return fmt.Errorf("fulfil %s: %w", bookID, ErrInvalidQuantity)
+	}
+	lvl, err := s.repo.Get(ctx, bookID)
+	if err != nil {
+		return fmt.Errorf("fulfil %s: %w", bookID, err)
+	}
+	if lvl.Reserved < qty {
+		return fmt.Errorf("fulfil %s: reserved %d, want %d: %w", bookID, lvl.Reserved, qty, ErrInvalidQuantity)
+	}
+	lvl.Reserved -= qty
+	if err := s.repo.Upsert(ctx, lvl); err != nil {
+		return fmt.Errorf("fulfil %s: persist: %w", bookID, err)
+	}
+	return nil
+}
+
+// Get returns the current Level for a book.
+func (s *Service) Get(ctx context.Context, bookID string) (Level, error) {
+	lvl, err := s.repo.Get(ctx, bookID)
+	if err != nil {
+		return Level{}, fmt.Errorf("get inventory: %w", err)
+	}
+	return lvl, nil
+}

--- a/go-bookstore/internal/inventory/inventory_test.go
+++ b/go-bookstore/internal/inventory/inventory_test.go
@@ -1,0 +1,81 @@
+package inventory
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func newService(t *testing.T) *Service {
+	t.Helper()
+	return NewService(NewInMemoryRepository())
+}
+
+func TestService_StockReserveRelease(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	ctx := context.Background()
+
+	if err := svc.Stock(ctx, "b1", 10); err != nil {
+		t.Fatalf("Stock: %v", err)
+	}
+	if err := svc.Reserve(ctx, "b1", 3); err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	lvl, _ := svc.Get(ctx, "b1")
+	if lvl.Available != 7 || lvl.Reserved != 3 {
+		t.Fatalf("expected 7/3, got %d/%d", lvl.Available, lvl.Reserved)
+	}
+
+	if err := svc.Release(ctx, "b1", 2); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	lvl, _ = svc.Get(ctx, "b1")
+	if lvl.Available != 9 || lvl.Reserved != 1 {
+		t.Fatalf("expected 9/1, got %d/%d", lvl.Available, lvl.Reserved)
+	}
+
+	if err := svc.Fulfil(ctx, "b1", 1); err != nil {
+		t.Fatalf("Fulfil: %v", err)
+	}
+	lvl, _ = svc.Get(ctx, "b1")
+	if lvl.Available != 9 || lvl.Reserved != 0 {
+		t.Fatalf("expected 9/0, got %d/%d", lvl.Available, lvl.Reserved)
+	}
+}
+
+func TestService_OutOfStock(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+	if err := svc.Stock(context.Background(), "b1", 2); err != nil {
+		t.Fatalf("Stock: %v", err)
+	}
+	err := svc.Reserve(context.Background(), "b1", 5)
+	if !errors.Is(err, ErrOutOfStock) {
+		t.Fatalf("expected ErrOutOfStock, got %v", err)
+	}
+}
+
+func TestService_InvalidQuantity(t *testing.T) {
+	t.Parallel()
+	svc := newService(t)
+
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{name: "stock zero", fn: func() error { return svc.Stock(context.Background(), "b", 0) }},
+		{name: "reserve negative", fn: func() error { return svc.Reserve(context.Background(), "b", -1) }},
+		{name: "release zero", fn: func() error { return svc.Release(context.Background(), "b", 0) }},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if err := tc.fn(); !errors.Is(err, ErrInvalidQuantity) {
+				t.Fatalf("expected ErrInvalidQuantity, got %v", err)
+			}
+		})
+	}
+}

--- a/go-bookstore/internal/order/errors.go
+++ b/go-bookstore/internal/order/errors.go
@@ -1,0 +1,17 @@
+package order
+
+import "errors"
+
+// Sentinel errors returned by the order package.
+var (
+	// ErrNotFound is returned when no order matches the requested id.
+	ErrNotFound = errors.New("order not found")
+	// ErrAlreadyExists is returned when an order id collision occurs on create.
+	ErrAlreadyExists = errors.New("order already exists")
+	// ErrEmpty is returned when the input order has no line items.
+	ErrEmpty = errors.New("order is empty")
+	// ErrInvalidStatus is returned when an invalid transition is attempted.
+	ErrInvalidStatus = errors.New("invalid status transition")
+	// ErrCurrencyMismatch is returned when line items mix currencies.
+	ErrCurrencyMismatch = errors.New("currency mismatch")
+)

--- a/go-bookstore/internal/order/order.go
+++ b/go-bookstore/internal/order/order.go
@@ -1,0 +1,53 @@
+// Package order contains the Order domain.
+package order
+
+import "time"
+
+// Status enumerates an Order's lifecycle states.
+type Status string
+
+const (
+	// StatusPending indicates an order awaiting payment.
+	StatusPending Status = "pending"
+	// StatusPaid indicates an order whose payment cleared.
+	StatusPaid Status = "paid"
+	// StatusShipped indicates an order shipped to the customer.
+	StatusShipped Status = "shipped"
+	// StatusCancelled indicates an order cancelled before shipment.
+	StatusCancelled Status = "cancelled"
+)
+
+// LineItem is a single line in an Order.
+type LineItem struct {
+	BookID     string `json:"bookId"`
+	Quantity   int    `json:"quantity"`
+	PriceCents int64  `json:"priceCents"`
+	Currency   string `json:"currency"`
+}
+
+// Order is a customer purchase.
+type Order struct {
+	ID           string     `json:"id"`
+	CustomerID   string     `json:"customerId"`
+	Items        []LineItem `json:"items"`
+	Status       Status     `json:"status"`
+	TotalCents   int64      `json:"totalCents"`
+	Currency     string     `json:"currency"`
+	CreatedAt    time.Time  `json:"createdAt"`
+	UpdatedAt    time.Time  `json:"updatedAt"`
+	PlacedAt     time.Time  `json:"placedAt,omitempty"`
+	ShippedAt    *time.Time `json:"shippedAt,omitempty"`
+	CancelledAt  *time.Time `json:"cancelledAt,omitempty"`
+	Notes        string     `json:"notes,omitempty"`
+	ShipAddress  string     `json:"shipAddress"`
+	BillAddress  string     `json:"billAddress"`
+}
+
+// Recompute updates TotalCents based on the current line items.
+func (o *Order) Recompute() {
+	var total int64
+	for _, item := range o.Items {
+		total += item.PriceCents * int64(item.Quantity)
+	}
+	o.TotalCents = total
+}

--- a/go-bookstore/internal/order/repository.go
+++ b/go-bookstore/internal/order/repository.go
@@ -1,0 +1,96 @@
+package order
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Repository is the storage contract used by the order Service.
+type Repository interface {
+	Create(ctx context.Context, o Order) error
+	Get(ctx context.Context, id string) (Order, error)
+	Update(ctx context.Context, o Order) error
+	ListByCustomer(ctx context.Context, customerID string, offset, limit int) ([]Order, error)
+}
+
+// InMemoryRepository is an in-process Repository for orders.
+type InMemoryRepository struct {
+	mu     sync.RWMutex
+	orders map[string]Order
+	byCust map[string][]string
+}
+
+// NewInMemoryRepository creates a new InMemoryRepository.
+func NewInMemoryRepository() *InMemoryRepository {
+	return &InMemoryRepository{
+		orders: make(map[string]Order),
+		byCust: make(map[string][]string),
+	}
+}
+
+// Create stores a new order.
+func (r *InMemoryRepository) Create(ctx context.Context, o Order) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("create order: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.orders[o.ID]; ok {
+		return fmt.Errorf("create order %s: %w", o.ID, ErrAlreadyExists)
+	}
+	r.orders[o.ID] = o
+	r.byCust[o.CustomerID] = append(r.byCust[o.CustomerID], o.ID)
+	return nil
+}
+
+// Get returns the order with the given id.
+func (r *InMemoryRepository) Get(ctx context.Context, id string) (Order, error) {
+	if err := ctx.Err(); err != nil {
+		return Order{}, fmt.Errorf("get order: %w", err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	o, ok := r.orders[id]
+	if !ok {
+		return Order{}, fmt.Errorf("get order %s: %w", id, ErrNotFound)
+	}
+	return o, nil
+}
+
+// Update replaces an existing order.
+func (r *InMemoryRepository) Update(ctx context.Context, o Order) error {
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("update order: %w", err)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.orders[o.ID]; !ok {
+		return fmt.Errorf("update order %s: %w", o.ID, ErrNotFound)
+	}
+	r.orders[o.ID] = o
+	return nil
+}
+
+// ListByCustomer returns orders for a customer, paged by offset and limit.
+func (r *InMemoryRepository) ListByCustomer(ctx context.Context, customerID string, offset, limit int) ([]Order, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("list orders for %s: %w", customerID, err)
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := r.byCust[customerID]
+	if offset >= len(ids) {
+		return []Order{}, nil
+	}
+	end := offset + limit
+	if end > len(ids) {
+		end = len(ids)
+	}
+	page := ids[offset:end]
+	out := make([]Order, 0, len(page))
+	for _, id := range page {
+		out = append(out, r.orders[id])
+	}
+	return out, nil
+}

--- a/go-bookstore/internal/order/service.go
+++ b/go-bookstore/internal/order/service.go
@@ -1,0 +1,166 @@
+package order
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/audit"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/inventory"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/token"
+)
+
+// Service is the application-level entry point for order operations.
+type Service struct {
+	repo      Repository
+	inventory *inventory.Service
+	audit     *audit.Log
+}
+
+// NewService constructs a Service.
+func NewService(repo Repository, stock *inventory.Service, auditLog *audit.Log) *Service {
+	return &Service{repo: repo, inventory: stock, audit: auditLog}
+}
+
+// PlaceInput is the data required to place a new order.
+type PlaceInput struct {
+	CustomerID  string
+	Items       []LineItem
+	ShipAddress string
+	BillAddress string
+	Notes       string
+}
+
+// Place validates the input, reserves stock, and persists the order.
+func (s *Service) Place(ctx context.Context, in PlaceInput) (Order, error) {
+	if len(in.Items) == 0 {
+		return Order{}, fmt.Errorf("place order: %w", ErrEmpty)
+	}
+	currency := in.Items[0].Currency
+	for _, it := range in.Items[1:] {
+		if it.Currency != currency {
+			return Order{}, fmt.Errorf("place order: %w", ErrCurrencyMismatch)
+		}
+	}
+
+	for _, it := range in.Items {
+		if err := s.inventory.Reserve(ctx, it.BookID, it.Quantity); err != nil {
+			return Order{}, fmt.Errorf("place order: reserve %s: %w", it.BookID, err)
+		}
+	}
+
+	now := time.Now().UTC()
+	id, err := token.NewID()
+	if err != nil {
+		return Order{}, fmt.Errorf("place order: generate id: %w", err)
+	}
+
+	o := Order{
+		ID:          id,
+		CustomerID:  in.CustomerID,
+		Items:       in.Items,
+		Status:      StatusPending,
+		Currency:    currency,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		PlacedAt:    now,
+		ShipAddress: in.ShipAddress,
+		BillAddress: in.BillAddress,
+		Notes:       in.Notes,
+	}
+	o.Recompute()
+	if err := s.repo.Create(ctx, o); err != nil {
+		return Order{}, fmt.Errorf("place order: persist: %w", err)
+	}
+
+	_ = s.audit.Append(ctx, audit.Entry{
+		Actor:  in.CustomerID,
+		Action: "order.place",
+		Target: o.ID,
+	})
+	return o, nil
+}
+
+// MarkPaid transitions an order from pending to paid.
+func (s *Service) MarkPaid(ctx context.Context, id string) (Order, error) {
+	o, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Order{}, fmt.Errorf("mark paid: %w", err)
+	}
+	if o.Status != StatusPending {
+		return Order{}, fmt.Errorf("mark paid: %w", ErrInvalidStatus)
+	}
+	o.Status = StatusPaid
+	o.UpdatedAt = time.Now().UTC()
+	if err := s.repo.Update(ctx, o); err != nil {
+		return Order{}, fmt.Errorf("mark paid: persist: %w", err)
+	}
+	return o, nil
+}
+
+// Ship transitions a paid order to shipped.
+func (s *Service) Ship(ctx context.Context, id string) (Order, error) {
+	o, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Order{}, fmt.Errorf("ship: %w", err)
+	}
+	if o.Status != StatusPaid {
+		return Order{}, fmt.Errorf("ship: %w", ErrInvalidStatus)
+	}
+	now := time.Now().UTC()
+	o.Status = StatusShipped
+	o.UpdatedAt = now
+	o.ShippedAt = &now
+	if err := s.repo.Update(ctx, o); err != nil {
+		return Order{}, fmt.Errorf("ship: persist: %w", err)
+	}
+	return o, nil
+}
+
+// Cancel transitions a pending or paid order to cancelled, releasing the stock.
+func (s *Service) Cancel(ctx context.Context, id string) (Order, error) {
+	o, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Order{}, fmt.Errorf("cancel: %w", err)
+	}
+	if o.Status != StatusPending && o.Status != StatusPaid {
+		return Order{}, fmt.Errorf("cancel: %w", ErrInvalidStatus)
+	}
+	for _, item := range o.Items {
+		if err := s.inventory.Release(ctx, item.BookID, item.Quantity); err != nil {
+			return Order{}, fmt.Errorf("cancel: release %s: %w", item.BookID, err)
+		}
+	}
+	now := time.Now().UTC()
+	o.Status = StatusCancelled
+	o.UpdatedAt = now
+	o.CancelledAt = &now
+	if err := s.repo.Update(ctx, o); err != nil {
+		return Order{}, fmt.Errorf("cancel: persist: %w", err)
+	}
+	return o, nil
+}
+
+// Get returns the order with the given id.
+func (s *Service) Get(ctx context.Context, id string) (Order, error) {
+	o, err := s.repo.Get(ctx, id)
+	if err != nil {
+		return Order{}, fmt.Errorf("get order: %w", err)
+	}
+	return o, nil
+}
+
+// ListByCustomer returns a page of orders for a customer.
+func (s *Service) ListByCustomer(ctx context.Context, customerID string, offset, limit int) ([]Order, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	orders, err := s.repo.ListByCustomer(ctx, customerID, offset, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list orders: %w", err)
+	}
+	return orders, nil
+}

--- a/go-bookstore/internal/order/service_test.go
+++ b/go-bookstore/internal/order/service_test.go
@@ -1,0 +1,122 @@
+package order
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/audit"
+	"github.com/Andrey-Test-Org/kittycat/go-bookstore/internal/inventory"
+)
+
+func newTestService(t *testing.T) *Service {
+	t.Helper()
+	stock := inventory.NewService(inventory.NewInMemoryRepository())
+	if err := stock.Stock(context.Background(), "book1", 10); err != nil {
+		t.Fatalf("stock book1: %v", err)
+	}
+	if err := stock.Stock(context.Background(), "book2", 10); err != nil {
+		t.Fatalf("stock book2: %v", err)
+	}
+	return NewService(NewInMemoryRepository(), stock, audit.NewLog())
+}
+
+func sampleItems() []LineItem {
+	return []LineItem{
+		{BookID: "book1", Quantity: 1, PriceCents: 1000, Currency: "USD"},
+		{BookID: "book2", Quantity: 2, PriceCents: 1500, Currency: "USD"},
+	}
+}
+
+func TestService_Place_Empty(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	_, err := svc.Place(context.Background(), PlaceInput{CustomerID: "c1"})
+	if !errors.Is(err, ErrEmpty) {
+		t.Fatalf("expected ErrEmpty, got %v", err)
+	}
+}
+
+func TestService_Place_CurrencyMismatch(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	items := sampleItems()
+	items[1].Currency = "EUR"
+	_, err := svc.Place(context.Background(), PlaceInput{CustomerID: "c1", Items: items})
+	if !errors.Is(err, ErrCurrencyMismatch) {
+		t.Fatalf("expected ErrCurrencyMismatch, got %v", err)
+	}
+}
+
+func TestService_Lifecycle(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	in := PlaceInput{
+		CustomerID:  "c1",
+		Items:       sampleItems(),
+		ShipAddress: "1 Cat Way",
+		BillAddress: "1 Cat Way",
+	}
+	o, err := svc.Place(context.Background(), in)
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+	if o.Status != StatusPending {
+		t.Fatalf("expected pending, got %s", o.Status)
+	}
+	if o.TotalCents != 1000+2*1500 {
+		t.Fatalf("expected %d, got %d", 1000+2*1500, o.TotalCents)
+	}
+
+	paid, err := svc.MarkPaid(context.Background(), o.ID)
+	if err != nil {
+		t.Fatalf("MarkPaid: %v", err)
+	}
+	if paid.Status != StatusPaid {
+		t.Fatalf("expected paid, got %s", paid.Status)
+	}
+
+	shipped, err := svc.Ship(context.Background(), o.ID)
+	if err != nil {
+		t.Fatalf("Ship: %v", err)
+	}
+	if shipped.Status != StatusShipped {
+		t.Fatalf("expected shipped, got %s", shipped.Status)
+	}
+}
+
+func TestService_Cancel(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	o, err := svc.Place(context.Background(), PlaceInput{CustomerID: "c1", Items: sampleItems()})
+	if err != nil {
+		t.Fatalf("Place: %v", err)
+	}
+	cancelled, err := svc.Cancel(context.Background(), o.ID)
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if cancelled.Status != StatusCancelled {
+		t.Fatalf("expected cancelled, got %s", cancelled.Status)
+	}
+	if cancelled.CancelledAt == nil {
+		t.Fatal("expected CancelledAt set")
+	}
+}
+
+func TestService_ListByCustomer(t *testing.T) {
+	t.Parallel()
+	svc := newTestService(t)
+	for i := 0; i < 3; i++ {
+		if _, err := svc.Place(context.Background(), PlaceInput{CustomerID: "c1", Items: sampleItems()}); err != nil {
+			t.Fatalf("Place: %v", err)
+		}
+	}
+	orders, err := svc.ListByCustomer(context.Background(), "c1", 0, 10)
+	if err != nil {
+		t.Fatalf("ListByCustomer: %v", err)
+	}
+	if len(orders) != 3 {
+		t.Fatalf("expected 3, got %d", len(orders))
+	}
+}

--- a/go-bookstore/internal/token/token.go
+++ b/go-bookstore/internal/token/token.go
@@ -1,0 +1,31 @@
+// Package token issues cryptographically random identifiers.
+package token
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+const (
+	idBytes     = 12
+	apiKeyBytes = 32
+)
+
+// NewID returns a hex-encoded 12-byte random identifier sourced from crypto/rand.
+func NewID() (string, error) {
+	buf := make([]byte, idBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("read crypto/rand: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+// NewAPIKey returns a hex-encoded 32-byte random API key sourced from crypto/rand.
+func NewAPIKey() (string, error) {
+	buf := make([]byte, apiKeyBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("read crypto/rand: %w", err)
+	}
+	return hex.EncodeToString(buf), nil
+}

--- a/go-bookstore/internal/token/token_test.go
+++ b/go-bookstore/internal/token/token_test.go
@@ -1,0 +1,68 @@
+package token
+
+import "testing"
+
+func TestNewID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want int
+	}{
+		{name: "24 hex chars", want: 24},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := NewID()
+			if err != nil {
+				t.Fatalf("NewID: %v", err)
+			}
+			if len(id) != tc.want {
+				t.Fatalf("length: want %d, got %d", tc.want, len(id))
+			}
+		})
+	}
+}
+
+func TestNewAPIKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		want int
+	}{
+		{name: "64 hex chars", want: 64},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			key, err := NewAPIKey()
+			if err != nil {
+				t.Fatalf("NewAPIKey: %v", err)
+			}
+			if len(key) != tc.want {
+				t.Fatalf("length: want %d, got %d", tc.want, len(key))
+			}
+		})
+	}
+}
+
+func TestNewID_Unique(t *testing.T) {
+	t.Parallel()
+	seen := make(map[string]struct{}, 200)
+	for i := 0; i < 200; i++ {
+		id, err := NewID()
+		if err != nil {
+			t.Fatalf("NewID: %v", err)
+		}
+		if _, dup := seen[id]; dup {
+			t.Fatalf("duplicate ID after %d iterations: %s", i, id)
+		}
+		seen[id] = struct{}{}
+	}
+}

--- a/kt-petstore/README.md
+++ b/kt-petstore/README.md
@@ -1,0 +1,194 @@
+# kt-petstore
+
+A Kotlin cat-adoption service backed by **Snowflake**. Manages shelters, breeds, cats, customers, carts, orders, inventory, and an audit trail.
+
+## Layout
+
+```
+kt-petstore/
+└── src/main/kotlin/petstore/
+    ├── Main.kt                    # entrypoint — demonstrates all 10 models + services
+    ├── model/Models.kt            # 10 data classes (one per table)
+    ├── db/Database.kt             # Snowflake JDBC connection + ResultSet helpers
+    ├── repository/Repositories.kt # 10 repository classes (CRUD via JDBC)
+    └── service/Services.kt        # 7 service classes with business logic
+```
+
+## 10 Tables
+
+| # | Table | Model class | Purpose |
+|---|-------|-------------|---------|
+| 1 | `customers` | `Customer` | People who adopt cats |
+| 2 | `breeds` | `Breed` | Cat breeds (Maine Coon, Siamese, etc.) |
+| 3 | `shelters` | `Shelter` | Rescue organisations / shelters |
+| 4 | `cats` | `Cat` | Cats available for adoption |
+| 5 | `carts` | `Cart` | A customer's pending selection |
+| 6 | `cart_items` | `CartItem` | Line items in a cart |
+| 7 | `orders` | `Order` | Adoption orders with lifecycle (pending → paid → shipped / cancelled) |
+| 8 | `order_items` | `OrderItem` | Line items in an order |
+| 9 | `inventory` | `Inventory` | Per-cat stock levels (available / reserved) |
+| 10 | `audit_log` | `AuditLog` | Append-only audit trail |
+
+## Run
+
+Requires the Snowflake JDBC driver on the classpath:
+
+```
+export SNOWFLAKE_ACCOUNT=youraccount
+export SNOWFLAKE_USER=youruser
+export SNOWFLAKE_PASSWORD=yourpassword
+export SNOWFLAKE_WAREHOUSE=yourwarehouse
+export SNOWFLAKE_ROLE=yourrole
+
+kotlinc src/main/kotlin/petstore -cp snowflake-jdbc-3.x.jar -d out
+java -cp out:snowflake-jdbc-3.x.jar petstore.MainKt
+```
+
+---
+
+## Snowflake Schema Creation Script
+
+Run this in a Snowflake worksheet. It creates the `PETSTORE` schema inside the **`TEST`** database with all 10 tables.
+
+```sql
+USE DATABASE TEST;
+
+CREATE SCHEMA IF NOT EXISTS PETSTORE;
+USE SCHEMA PETSTORE;
+
+-- 1. customers
+CREATE TABLE IF NOT EXISTS customers (
+    id           STRING       NOT NULL,
+    full_name    STRING       NOT NULL,
+    email        STRING       NOT NULL,
+    phone        STRING,
+    address      STRING       NOT NULL,
+    created_at   TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    updated_at   TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id)
+);
+
+-- 2. breeds
+CREATE TABLE IF NOT EXISTS breeds (
+    id                STRING       NOT NULL,
+    name              STRING       NOT NULL,
+    description       STRING,
+    origin_country    STRING       NOT NULL,
+    avg_lifespan_years INT          NOT NULL,
+    created_at        TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    updated_at        TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id)
+);
+
+-- 3. shelters
+CREATE TABLE IF NOT EXISTS shelters (
+    id          STRING       NOT NULL,
+    name        STRING       NOT NULL,
+    address     STRING       NOT NULL,
+    phone       STRING,
+    email       STRING,
+    created_at  TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    updated_at  TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id)
+);
+
+-- 4. cats
+CREATE TABLE IF NOT EXISTS cats (
+    id           STRING       NOT NULL,
+    name         STRING       NOT NULL,
+    breed_id     STRING       NOT NULL,
+    shelter_id   STRING       NOT NULL,
+    birth_date   DATE         NOT NULL,
+    price_cents  NUMBER(12,2) NOT NULL,
+    currency     STRING(3)    NOT NULL,
+    status       STRING       NOT NULL DEFAULT 'AVAILABLE',
+    description  STRING,
+    created_at   TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    updated_at   TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id),
+    FOREIGN KEY (breed_id)   REFERENCES breeds (id),
+    FOREIGN KEY (shelter_id) REFERENCES shelters (id)
+);
+
+-- 5. carts
+CREATE TABLE IF NOT EXISTS carts (
+    id          STRING       NOT NULL,
+    customer_id STRING       NOT NULL,
+    created_at  TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    updated_at  TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id),
+    FOREIGN KEY (customer_id) REFERENCES customers (id)
+);
+
+-- 6. cart_items
+CREATE TABLE IF NOT EXISTS cart_items (
+    id         STRING       NOT NULL,
+    cart_id    STRING       NOT NULL,
+    cat_id     STRING       NOT NULL,
+    quantity   INT          NOT NULL CHECK (quantity > 0),
+    created_at TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id),
+    FOREIGN KEY (cart_id) REFERENCES carts (id),
+    FOREIGN KEY (cat_id)  REFERENCES cats (id)
+);
+
+-- 7. orders
+CREATE TABLE IF NOT EXISTS orders (
+    id           STRING       NOT NULL,
+    customer_id  STRING       NOT NULL,
+    status       STRING       NOT NULL DEFAULT 'PENDING',
+    total_cents  NUMBER(12,2) NOT NULL,
+    currency     STRING(3)    NOT NULL,
+    ship_address STRING       NOT NULL,
+    bill_address STRING       NOT NULL,
+    notes        STRING,
+    created_at   TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    updated_at   TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    placed_at    TIMESTAMP_NTZ,
+    shipped_at   TIMESTAMP_NTZ,
+    cancelled_at TIMESTAMP_NTZ,
+    PRIMARY KEY (id),
+    FOREIGN KEY (customer_id) REFERENCES customers (id)
+);
+
+-- 8. order_items
+CREATE TABLE IF NOT EXISTS order_items (
+    id          STRING       NOT NULL,
+    order_id    STRING       NOT NULL,
+    cat_id      STRING       NOT NULL,
+    quantity    INT          NOT NULL CHECK (quantity > 0),
+    price_cents NUMBER(12,2) NOT NULL,
+    currency    STRING(3)    NOT NULL,
+    created_at  TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id),
+    FOREIGN KEY (order_id) REFERENCES orders (id),
+    FOREIGN KEY (cat_id)   REFERENCES cats (id)
+);
+
+-- 9. inventory
+CREATE TABLE IF NOT EXISTS inventory (
+    cat_id     STRING       NOT NULL,
+    available  INT          NOT NULL DEFAULT 0,
+    reserved   INT          NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (cat_id),
+    FOREIGN KEY (cat_id) REFERENCES cats (id)
+);
+
+-- 10. audit_log
+CREATE TABLE IF NOT EXISTS audit_log (
+    id         STRING       NOT NULL,
+    actor      STRING       NOT NULL,
+    action     STRING       NOT NULL,
+    target     STRING       NOT NULL,
+    created_at TIMESTAMP_NTZ NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    PRIMARY KEY (id)
+);
+```
+
+### Drop (clean slate)
+
+```sql
+USE DATABASE TEST;
+DROP SCHEMA IF EXISTS PETSTORE CASCADE;
+```

--- a/kt-petstore/src/main/kotlin/petstore/Main.kt
+++ b/kt-petstore/src/main/kotlin/petstore/Main.kt
@@ -1,0 +1,167 @@
+package petstore
+
+import petstore.db.Database
+import petstore.db.SnowflakeConfig
+import petstore.model.*
+import petstore.repository.*
+import petstore.service.*
+import java.time.LocalDate
+
+fun main() {
+    val config = SnowflakeConfig(
+        account = System.getenv("SNOWFLAKE_ACCOUNT"),
+        user = System.getenv("SNOWFLAKE_USER"),
+        password = System.getenv("SNOWFLAKE_PASSWORD"),
+        database = "TEST",
+        schema = "PETSTORE",
+        warehouse = System.getenv("SNOWFLAKE_WAREHOUSE"),
+        role = System.getenv("SNOWFLAKE_ROLE"),
+    )
+
+    Database(config).use { db ->
+        val customerRepo = CustomerRepository(db)
+        val breedRepo = BreedRepository(db)
+        val shelterRepo = ShelterRepository(db)
+        val catRepo = CatRepository(db)
+        val cartRepo = CartRepository(db)
+        val cartItemRepo = CartItemRepository(db)
+        val orderRepo = OrderRepository(db)
+        val orderItemRepo = OrderItemRepository(db)
+        val inventoryRepo = InventoryRepository(db)
+        val auditRepo = AuditLogRepository(db)
+
+        val inventoryService = InventoryService(inventoryRepo)
+        val auditService = AuditService(auditRepo)
+        val catService = CatService(catRepo, breedRepo, shelterRepo, inventoryService)
+        val cartService = CartService(cartRepo, cartItemRepo, inventoryService)
+        val orderService = OrderService(orderRepo, orderItemRepo, catRepo, inventoryService, auditService)
+        val customerService = CustomerService(customerRepo)
+        val breedService = BreedService(breedRepo)
+        val shelterService = ShelterService(shelterRepo)
+
+        println("=== Cat Adoption Store ===")
+
+        val shelter = shelterService.create(
+            name = "Whiskers Rescue",
+            address = "123 Purr Lane, Catherton",
+            phone = "555-0123",
+            email = "adopt@whiskers.org",
+        )
+        println("Created shelter: $shelter")
+
+        val breed = breedService.create(
+            name = "Maine Coon",
+            description = "Large, gentle, fluffy",
+            originCountry = "USA",
+            avgLifespanYears = 13,
+        )
+        println("Created breed: $breed")
+
+        val breed2 = breedService.create(
+            name = "Siamese",
+            description = "Vocal, sleek, social",
+            originCountry = "Thailand",
+            avgLifespanYears = 15,
+        )
+        println("Created breed: $breed2")
+
+        val customer = customerService.create(
+            fullName = "Alice Johnson",
+            email = "alice@example.com",
+            phone = "555-9999",
+            address = "456 Felidae St, Meowville",
+        )
+        println("Created customer: $customer")
+
+        val cat1 = catService.create(
+            name = "Luna",
+            breedId = breed.id,
+            shelterId = shelter.id,
+            birthDate = LocalDate.of(2023, 5, 14),
+            priceCents = 25000,
+            currency = "USD",
+            description = "Friendly, loves cuddles",
+        )
+        println("Created cat: ${cat1.name} (${cat1.status})")
+
+        val cat2 = catService.create(
+            name = "Simba",
+            breedId = breed2.id,
+            shelterId = shelter.id,
+            birthDate = LocalDate.of(2022, 8, 1),
+            priceCents = 30000,
+            currency = "USD",
+            description = "Very talkative, loves warmth",
+        )
+        println("Created cat: ${cat2.name} (${cat2.status})")
+
+        val cat3 = catService.create(
+            name = "Luna Bell",
+            breedId = breed.id,
+            shelterId = shelter.id,
+            birthDate = LocalDate.of(2024, 1, 20),
+            priceCents = 20000,
+            currency = "USD",
+            description = "Playful kitten",
+        )
+        println("Created cat: ${cat3.name} (${cat3.status})")
+
+        println("\nSearch results for 'Luna':")
+        catService.search("Luna").forEach { println("  - ${it.name} (id=${it.id})") }
+
+        println("\nInventory for ${cat1.name}: ${inventoryService.get(cat1.id)}")
+
+        val cart = cartService.create(customer.id)
+        cartService.addItem(cart.id, cat1.id, 1)
+        cartService.addItem(cart.id, cat3.id, 1)
+        println("\nCart ${cart.id} items:")
+        cartService.items(cart.id).forEach { println("  - catId=${it.catId} qty=${it.quantity}") }
+
+        val order = orderService.place(
+            customerId = customer.id,
+            items = listOf(cat1.id to 1, cat3.id to 1),
+            currency = "USD",
+            shipAddress = customer.address,
+            billAddress = customer.address,
+            notes = "Please deliver in the morning",
+        )
+        println("\nPlaced order: ${order.id} status=${order.status} total=${order.totalCents}")
+        println("Order items:")
+        orderService.items(order.id).forEach { println("  - catId=${it.catId} qty=${it.quantity} price=${it.priceCents}") }
+
+        val paid = orderService.markPaid(order.id)
+        println("Order paid: status=${paid.status}")
+
+        val shipped = orderService.ship(order.id)
+        println("Order shipped: status=${shipped.status} shippedAt=${shipped.shippedAt}")
+
+        catService.markAdopted(cat1.id)
+        catService.markAdopted(cat3.id)
+        println("\n${cat1.name} status: ${catService.get(cat1.id).status}")
+        println("${cat3.name} status: ${catService.get(cat3.id).status}")
+
+        println("\nRecent audit log:")
+        auditService.recent(10).forEach { e ->
+            println("  - [${e.createdAt}] ${e.actor} ${e.action} -> ${e.target}")
+        }
+
+        println("\nAll breeds:")
+        breedService.list().forEach { println("  - ${it.name} (${it.originCountry})" ) }
+
+        println("\nAll shelters:")
+        shelterService.list().forEach { println("  - ${it.name} (${it.address})" ) }
+
+        println("\nCustomer orders:")
+        customerService.list().forEach { c ->
+            println("  Customer: ${c.fullName}")
+            orderService.listByCustomer(c.id).forEach { o ->
+                println("    Order ${o.id}: ${o.status} total=${o.totalCents} ${o.currency}")
+            }
+        }
+
+        cartService.clear(cart.id)
+        println("\nCart cleared: ${cart.id}")
+
+        println("\n=== Done ===")
+    }
+}

--- a/kt-petstore/src/main/kotlin/petstore/db/Database.kt
+++ b/kt-petstore/src/main/kotlin/petstore/db/Database.kt
@@ -1,0 +1,45 @@
+package petstore.db
+
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+
+data class SnowflakeConfig(
+    val account: String,
+    val user: String,
+    val password: String,
+    val database: String = "TEST",
+    val schema: String = "PETSTORE",
+    val warehouse: String,
+    val role: String,
+)
+
+class Database(private val config: SnowflakeConfig) : AutoCloseable {
+
+    private val connection: Connection = DriverManager.getConnection(jdbcUrl(), config.user, config.password)
+
+    private fun jdbcUrl(): String {
+        return "jdbc:snowflake://${config.account}.snowflakecomputing.com" +
+            "/?db=${config.database}&schema=${config.schema}&warehouse=${config.warehouse}&role=${config.role}"
+    }
+
+    fun connection(): Connection = connection
+
+    override fun close() {
+        if (!connection.isClosed) connection.close()
+    }
+}
+
+fun ResultSet.getInstant(col: String): Instant? =
+    getTimestamp(col)?.let { it.toInstant() }
+
+fun ResultSet.getInstant(col: Int): Instant? =
+    getTimestamp(col)?.let { it.toInstant() }
+
+fun ResultSet.getLocalDate(col: String): LocalDate? =
+    getDate(col)?.let { it.toLocalDate() }
+
+fun Instant.toSqlTimestamp(): Timestamp = Timestamp.from(this)

--- a/kt-petstore/src/main/kotlin/petstore/model/Models.kt
+++ b/kt-petstore/src/main/kotlin/petstore/model/Models.kt
@@ -1,0 +1,107 @@
+package petstore.model
+
+import java.time.Instant
+
+data class Customer(
+    val id: String,
+    val fullName: String,
+    val email: String,
+    val phone: String?,
+    val address: String,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+)
+
+data class Breed(
+    val id: String,
+    val name: String,
+    val description: String?,
+    val originCountry: String,
+    val avgLifespanYears: Int,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+)
+
+data class Shelter(
+    val id: String,
+    val name: String,
+    val address: String,
+    val phone: String?,
+    val email: String?,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+)
+
+enum class CatStatus { AVAILABLE, RESERVED, ADOPTED, RETIRED }
+
+data class Cat(
+    val id: String,
+    val name: String,
+    val breedId: String,
+    val shelterId: String,
+    val birthDate: java.time.LocalDate,
+    val priceCents: Long,
+    val currency: String,
+    val status: CatStatus = CatStatus.AVAILABLE,
+    val description: String?,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+)
+
+data class Cart(
+    val id: String,
+    val customerId: String,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+)
+
+data class CartItem(
+    val id: String,
+    val cartId: String,
+    val catId: String,
+    val quantity: Int,
+    val createdAt: Instant = Instant.now(),
+)
+
+enum class OrderStatus { PENDING, PAID, SHIPPED, CANCELLED }
+
+data class Order(
+    val id: String,
+    val customerId: String,
+    val status: OrderStatus = OrderStatus.PENDING,
+    val totalCents: Long,
+    val currency: String,
+    val shipAddress: String,
+    val billAddress: String,
+    val notes: String? = null,
+    val createdAt: Instant = Instant.now(),
+    val updatedAt: Instant = Instant.now(),
+    val placedAt: Instant? = null,
+    val shippedAt: Instant? = null,
+    val cancelledAt: Instant? = null,
+)
+
+data class OrderItem(
+    val id: String,
+    val orderId: String,
+    val catId: String,
+    val quantity: Int,
+    val priceCents: Long,
+    val currency: String,
+    val createdAt: Instant = Instant.now(),
+)
+
+data class Inventory(
+    val catId: String,
+    val available: Int,
+    val reserved: Int,
+    val updatedAt: Instant = Instant.now(),
+)
+
+data class AuditLog(
+    val id: String,
+    val actor: String,
+    val action: String,
+    val target: String,
+    val createdAt: Instant = Instant.now(),
+)

--- a/kt-petstore/src/main/kotlin/petstore/repository/Repositories.kt
+++ b/kt-petstore/src/main/kotlin/petstore/repository/Repositories.kt
@@ -1,0 +1,585 @@
+package petstore.repository
+
+import petstore.db.Database
+import petstore.db.getInstant
+import petstore.db.getLocalDate
+import petstore.db.toSqlTimestamp
+import petstore.model.*
+import java.sql.SQLException
+import java.time.Instant
+
+class NotFoundException(message: String) : RuntimeException(message)
+
+class CustomerRepository(private val db: Database) {
+
+    fun create(c: Customer): Customer {
+        val sql = """
+            INSERT INTO customers (id, full_name, email, phone, address, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, c.id)
+            ps.setString(2, c.fullName)
+            ps.setString(3, c.email)
+            ps.setString(4, c.phone)
+            ps.setString(5, c.address)
+            ps.setTimestamp(6, c.createdAt.toSqlTimestamp())
+            ps.setTimestamp(7, c.updatedAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return c
+    }
+
+    fun findById(id: String): Customer? {
+        val sql = "SELECT id, full_name, email, phone, address, created_at, updated_at FROM customers WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, id)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToCustomer(rs)
+            }
+        }
+        return null
+    }
+
+    fun list(offset: Int, limit: Int): List<Customer> {
+        val sql = "SELECT id, full_name, email, phone, address, created_at, updated_at FROM customers ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        val results = mutableListOf<Customer>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setInt(1, limit)
+            ps.setInt(2, offset)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToCustomer(rs))
+            }
+        }
+        return results
+    }
+
+    fun update(c: Customer): Customer {
+        val sql = """
+            UPDATE customers
+            SET full_name = ?, email = ?, phone = ?, address = ?, updated_at = ?
+            WHERE id = ?
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, c.fullName)
+            ps.setString(2, c.email)
+            ps.setString(3, c.phone)
+            ps.setString(4, c.address)
+            ps.setTimestamp(5, Instant.now().toSqlTimestamp())
+            ps.setString(6, c.id)
+            val rows = ps.executeUpdate()
+            if (rows == 0) throw NotFoundException("customer ${c.id} not found")
+        }
+        return c
+    }
+
+    fun delete(id: String) {
+        db.connection().prepareStatement("DELETE FROM customers WHERE id = ?").use { ps ->
+            ps.setString(1, id)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun rsToCustomer(rs: java.sql.ResultSet) = Customer(
+        id = rs.getString("id"),
+        fullName = rs.getString("full_name"),
+        email = rs.getString("email"),
+        phone = rs.getString("phone"),
+        address = rs.getString("address"),
+        createdAt = rs.getInstant("created_at")!!,
+        updatedAt = rs.getInstant("updated_at")!!,
+    )
+}
+
+class BreedRepository(private val db: Database) {
+
+    fun create(b: Breed): Breed {
+        val sql = """
+            INSERT INTO breeds (id, name, description, origin_country, avg_lifespan_years, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, b.id)
+            ps.setString(2, b.name)
+            ps.setString(3, b.description)
+            ps.setString(4, b.originCountry)
+            ps.setInt(5, b.avgLifespanYears)
+            ps.setTimestamp(6, b.createdAt.toSqlTimestamp())
+            ps.setTimestamp(7, b.updatedAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return b
+    }
+
+    fun findById(id: String): Breed? {
+        val sql = "SELECT id, name, description, origin_country, avg_lifespan_years, created_at, updated_at FROM breeds WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, id)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToBreed(rs)
+            }
+        }
+        return null
+    }
+
+    fun list(): List<Breed> {
+        val sql = "SELECT id, name, description, origin_country, avg_lifespan_years, created_at, updated_at FROM breeds ORDER BY name"
+        val results = mutableListOf<Breed>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToBreed(rs))
+            }
+        }
+        return results
+    }
+
+    private fun rsToBreed(rs: java.sql.ResultSet) = Breed(
+        id = rs.getString("id"),
+        name = rs.getString("name"),
+        description = rs.getString("description"),
+        originCountry = rs.getString("origin_country"),
+        avgLifespanYears = rs.getInt("avg_lifespan_years"),
+        createdAt = rs.getInstant("created_at")!!,
+        updatedAt = rs.getInstant("updated_at")!!,
+    )
+}
+
+class ShelterRepository(private val db: Database) {
+
+    fun create(s: Shelter): Shelter {
+        val sql = """
+            INSERT INTO shelters (id, name, address, phone, email, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, s.id)
+            ps.setString(2, s.name)
+            ps.setString(3, s.address)
+            ps.setString(4, s.phone)
+            ps.setString(5, s.email)
+            ps.setTimestamp(6, s.createdAt.toSqlTimestamp())
+            ps.setTimestamp(7, s.updatedAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return s
+    }
+
+    fun findById(id: String): Shelter? {
+        val sql = "SELECT id, name, address, phone, email, created_at, updated_at FROM shelters WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, id)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToShelter(rs)
+            }
+        }
+        return null
+    }
+
+    fun list(): List<Shelter> {
+        val sql = "SELECT id, name, address, phone, email, created_at, updated_at FROM shelters ORDER BY name"
+        val results = mutableListOf<Shelter>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToShelter(rs))
+            }
+        }
+        return results
+    }
+
+    private fun rsToShelter(rs: java.sql.ResultSet) = Shelter(
+        id = rs.getString("id"),
+        name = rs.getString("name"),
+        address = rs.getString("address"),
+        phone = rs.getString("phone"),
+        email = rs.getString("email"),
+        createdAt = rs.getInstant("created_at")!!,
+        updatedAt = rs.getInstant("updated_at")!!,
+    )
+}
+
+class CatRepository(private val db: Database) {
+
+    fun create(c: Cat): Cat {
+        val sql = """
+            INSERT INTO cats (id, name, breed_id, shelter_id, birth_date, price_cents, currency, status, description, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, c.id)
+            ps.setString(2, c.name)
+            ps.setString(3, c.breedId)
+            ps.setString(4, c.shelterId)
+            ps.setDate(5, java.sql.Date.valueOf(c.birthDate))
+            ps.setLong(6, c.priceCents)
+            ps.setString(7, c.currency)
+            ps.setString(8, c.status.name)
+            ps.setString(9, c.description)
+            ps.setTimestamp(10, c.createdAt.toSqlTimestamp())
+            ps.setTimestamp(11, c.updatedAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return c
+    }
+
+    fun findById(id: String): Cat? {
+        val sql = "SELECT id, name, breed_id, shelter_id, birth_date, price_cents, currency, status, description, created_at, updated_at FROM cats WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, id)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToCat(rs)
+            }
+        }
+        return null
+    }
+
+    fun list(offset: Int, limit: Int): List<Cat> {
+        val sql = "SELECT id, name, breed_id, shelter_id, birth_date, price_cents, currency, status, description, created_at, updated_at FROM cats ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        val results = mutableListOf<Cat>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setInt(1, limit)
+            ps.setInt(2, offset)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToCat(rs))
+            }
+        }
+        return results
+    }
+
+    fun searchByName(query: String, limit: Int): List<Cat> {
+        val sql = "SELECT id, name, breed_id, shelter_id, birth_date, price_cents, currency, status, description, created_at, updated_at FROM cats WHERE name ILIKE ? ORDER BY name LIMIT ?"
+        val results = mutableListOf<Cat>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, "%$query%")
+            ps.setInt(2, limit)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToCat(rs))
+            }
+        }
+        return results
+    }
+
+    fun updateStatus(id: String, status: CatStatus) {
+        val sql = "UPDATE cats SET status = ?, updated_at = ? WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, status.name)
+            ps.setTimestamp(2, Instant.now().toSqlTimestamp())
+            ps.setString(3, id)
+            val rows = ps.executeUpdate()
+            if (rows == 0) throw NotFoundException("cat $id not found")
+        }
+    }
+
+    fun delete(id: String) {
+        db.connection().prepareStatement("DELETE FROM cats WHERE id = ?").use { ps ->
+            ps.setString(1, id)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun rsToCat(rs: java.sql.ResultSet) = Cat(
+        id = rs.getString("id"),
+        name = rs.getString("name"),
+        breedId = rs.getString("breed_id"),
+        shelterId = rs.getString("shelter_id"),
+        birthDate = rs.getLocalDate("birth_date")!!,
+        priceCents = rs.getLong("price_cents"),
+        currency = rs.getString("currency"),
+        status = CatStatus.valueOf(rs.getString("status")),
+        description = rs.getString("description"),
+        createdAt = rs.getInstant("created_at")!!,
+        updatedAt = rs.getInstant("updated_at")!!,
+    )
+}
+
+class CartRepository(private val db: Database) {
+
+    fun create(cart: Cart): Cart {
+        val sql = "INSERT INTO carts (id, customer_id, created_at, updated_at) VALUES (?, ?, ?, ?)"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, cart.id)
+            ps.setString(2, cart.customerId)
+            ps.setTimestamp(3, cart.createdAt.toSqlTimestamp())
+            ps.setTimestamp(4, cart.updatedAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return cart
+    }
+
+    fun findById(id: String): Cart? {
+        val sql = "SELECT id, customer_id, created_at, updated_at FROM carts WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, id)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToCart(rs)
+            }
+        }
+        return null
+    }
+
+    fun delete(id: String) {
+        db.connection().prepareStatement("DELETE FROM carts WHERE id = ?").use { ps ->
+            ps.setString(1, id)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun rsToCart(rs: java.sql.ResultSet) = Cart(
+        id = rs.getString("id"),
+        customerId = rs.getString("customer_id"),
+        createdAt = rs.getInstant("created_at")!!,
+        updatedAt = rs.getInstant("updated_at")!!,
+    )
+}
+
+class CartItemRepository(private val db: Database) {
+
+    fun create(item: CartItem): CartItem {
+        val sql = "INSERT INTO cart_items (id, cart_id, cat_id, quantity, created_at) VALUES (?, ?, ?, ?, ?)"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, item.id)
+            ps.setString(2, item.cartId)
+            ps.setString(3, item.catId)
+            ps.setInt(4, item.quantity)
+            ps.setTimestamp(5, item.createdAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return item
+    }
+
+    fun findByCart(cartId: String): List<CartItem> {
+        val sql = "SELECT id, cart_id, cat_id, quantity, created_at FROM cart_items WHERE cart_id = ? ORDER BY created_at"
+        val results = mutableListOf<CartItem>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, cartId)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToCartItem(rs))
+            }
+        }
+        return results
+    }
+
+    fun delete(cartId: String, catId: String) {
+        db.connection().prepareStatement("DELETE FROM cart_items WHERE cart_id = ? AND cat_id = ?").use { ps ->
+            ps.setString(1, cartId)
+            ps.setString(2, catId)
+            ps.executeUpdate()
+        }
+    }
+
+    fun deleteAllByCart(cartId: String) {
+        db.connection().prepareStatement("DELETE FROM cart_items WHERE cart_id = ?").use { ps ->
+            ps.setString(1, cartId)
+            ps.executeUpdate()
+        }
+    }
+
+    private fun rsToCartItem(rs: java.sql.ResultSet) = CartItem(
+        id = rs.getString("id"),
+        cartId = rs.getString("cart_id"),
+        catId = rs.getString("cat_id"),
+        quantity = rs.getInt("quantity"),
+        createdAt = rs.getInstant("created_at")!!,
+    )
+}
+
+class OrderRepository(private val db: Database) {
+
+    fun create(o: Order): Order {
+        val sql = """
+            INSERT INTO orders (id, customer_id, status, total_cents, currency, ship_address, bill_address, notes, created_at, updated_at, placed_at, shipped_at, cancelled_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, o.id)
+            ps.setString(2, o.customerId)
+            ps.setString(3, o.status.name)
+            ps.setLong(4, o.totalCents)
+            ps.setString(5, o.currency)
+            ps.setString(6, o.shipAddress)
+            ps.setString(7, o.billAddress)
+            ps.setString(8, o.notes)
+            ps.setTimestamp(9, o.createdAt.toSqlTimestamp())
+            ps.setTimestamp(10, o.updatedAt.toSqlTimestamp())
+            ps.setTimestamp(11, o.placedAt?.toSqlTimestamp())
+            ps.setTimestamp(12, o.shippedAt?.toSqlTimestamp())
+            ps.setTimestamp(13, o.cancelledAt?.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return o
+    }
+
+    fun findById(id: String): Order? {
+        val sql = "SELECT id, customer_id, status, total_cents, currency, ship_address, bill_address, notes, created_at, updated_at, placed_at, shipped_at, cancelled_at FROM orders WHERE id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, id)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToOrder(rs)
+            }
+        }
+        return null
+    }
+
+    fun listByCustomer(customerId: String, offset: Int, limit: Int): List<Order> {
+        val sql = "SELECT id, customer_id, status, total_cents, currency, ship_address, bill_address, notes, created_at, updated_at, placed_at, shipped_at, cancelled_at FROM orders WHERE customer_id = ? ORDER BY created_at DESC LIMIT ? OFFSET ?"
+        val results = mutableListOf<Order>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, customerId)
+            ps.setInt(2, limit)
+            ps.setInt(3, offset)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToOrder(rs))
+            }
+        }
+        return results
+    }
+
+    fun update(o: Order): Order {
+        val sql = """
+            UPDATE orders
+            SET status = ?, total_cents = ?, updated_at = ?, placed_at = ?, shipped_at = ?, cancelled_at = ?
+            WHERE id = ?
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, o.status.name)
+            ps.setLong(2, o.totalCents)
+            ps.setTimestamp(3, Instant.now().toSqlTimestamp())
+            ps.setTimestamp(4, o.placedAt?.toSqlTimestamp())
+            ps.setTimestamp(5, o.shippedAt?.toSqlTimestamp())
+            ps.setTimestamp(6, o.cancelledAt?.toSqlTimestamp())
+            ps.setString(7, o.id)
+            val rows = ps.executeUpdate()
+            if (rows == 0) throw NotFoundException("order ${o.id} not found")
+        }
+        return o
+    }
+
+    private fun rsToOrder(rs: java.sql.ResultSet) = Order(
+        id = rs.getString("id"),
+        customerId = rs.getString("customer_id"),
+        status = OrderStatus.valueOf(rs.getString("status")),
+        totalCents = rs.getLong("total_cents"),
+        currency = rs.getString("currency"),
+        shipAddress = rs.getString("ship_address"),
+        billAddress = rs.getString("bill_address"),
+        notes = rs.getString("notes"),
+        createdAt = rs.getInstant("created_at")!!,
+        updatedAt = rs.getInstant("updated_at")!!,
+        placedAt = rs.getInstant("placed_at"),
+        shippedAt = rs.getInstant("shipped_at"),
+        cancelledAt = rs.getInstant("cancelled_at"),
+    )
+}
+
+class OrderItemRepository(private val db: Database) {
+
+    fun create(item: OrderItem): OrderItem {
+        val sql = "INSERT INTO order_items (id, order_id, cat_id, quantity, price_cents, currency, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, item.id)
+            ps.setString(2, item.orderId)
+            ps.setString(3, item.catId)
+            ps.setInt(4, item.quantity)
+            ps.setLong(5, item.priceCents)
+            ps.setString(6, item.currency)
+            ps.setTimestamp(7, item.createdAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return item
+    }
+
+    fun findByOrder(orderId: String): List<OrderItem> {
+        val sql = "SELECT id, order_id, cat_id, quantity, price_cents, currency, created_at FROM order_items WHERE order_id = ? ORDER BY created_at"
+        val results = mutableListOf<OrderItem>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, orderId)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToOrderItem(rs))
+            }
+        }
+        return results
+    }
+
+    private fun rsToOrderItem(rs: java.sql.ResultSet) = OrderItem(
+        id = rs.getString("id"),
+        orderId = rs.getString("order_id"),
+        catId = rs.getString("cat_id"),
+        quantity = rs.getInt("quantity"),
+        priceCents = rs.getLong("price_cents"),
+        currency = rs.getString("currency"),
+        createdAt = rs.getInstant("created_at")!!,
+    )
+}
+
+class InventoryRepository(private val db: Database) {
+
+    fun upsert(inv: Inventory) {
+        val sql = """
+            MERGE INTO inventory t
+            USING (SELECT ? AS cat_id, ? AS available, ? AS reserved, ? AS updated_at) s
+            ON t.cat_id = s.cat_id
+            WHEN MATCHED THEN UPDATE SET available = s.available, reserved = s.reserved, updated_at = s.updated_at
+            WHEN NOT MATCHED THEN INSERT (cat_id, available, reserved, updated_at) VALUES (s.cat_id, s.available, s.reserved, s.updated_at)
+        """.trimIndent()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, inv.catId)
+            ps.setInt(2, inv.available)
+            ps.setInt(3, inv.reserved)
+            ps.setTimestamp(4, inv.updatedAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+    }
+
+    fun findByCat(catId: String): Inventory? {
+        val sql = "SELECT cat_id, available, reserved, updated_at FROM inventory WHERE cat_id = ?"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, catId)
+            ps.executeQuery().use { rs ->
+                if (rs.next()) return rsToInventory(rs)
+            }
+        }
+        return null
+    }
+
+    private fun rsToInventory(rs: java.sql.ResultSet) = Inventory(
+        catId = rs.getString("cat_id"),
+        available = rs.getInt("available"),
+        reserved = rs.getInt("reserved"),
+        updatedAt = rs.getInstant("updated_at")!!,
+    )
+}
+
+class AuditLogRepository(private val db: Database) {
+
+    fun append(entry: AuditLog): AuditLog {
+        val sql = "INSERT INTO audit_log (id, actor, action, target, created_at) VALUES (?, ?, ?, ?, ?)"
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setString(1, entry.id)
+            ps.setString(2, entry.actor)
+            ps.setString(3, entry.action)
+            ps.setString(4, entry.target)
+            ps.setTimestamp(5, entry.createdAt.toSqlTimestamp())
+            ps.executeUpdate()
+        }
+        return entry
+    }
+
+    fun list(limit: Int): List<AuditLog> {
+        val sql = "SELECT id, actor, action, target, created_at FROM audit_log ORDER BY created_at DESC LIMIT ?"
+        val results = mutableListOf<AuditLog>()
+        db.connection().prepareStatement(sql).use { ps ->
+            ps.setInt(1, limit)
+            ps.executeQuery().use { rs ->
+                while (rs.next()) results.add(rsToAuditLog(rs))
+            }
+        }
+        return results
+    }
+
+    private fun rsToAuditLog(rs: java.sql.ResultSet) = AuditLog(
+        id = rs.getString("id"),
+        actor = rs.getString("actor"),
+        action = rs.getString("action"),
+        target = rs.getString("target"),
+        createdAt = rs.getInstant("created_at")!!,
+    )
+}

--- a/kt-petstore/src/main/kotlin/petstore/service/Services.kt
+++ b/kt-petstore/src/main/kotlin/petstore/service/Services.kt
@@ -1,0 +1,322 @@
+package petstore.service
+
+import petstore.model.*
+import petstore.repository.*
+import java.time.Instant
+import java.util.UUID
+
+class CustomerService(private val repo: CustomerRepository) {
+
+    fun create(fullName: String, email: String, phone: String?, address: String): Customer {
+        require(fullName.isNotBlank()) { "fullName must not be blank" }
+        require(email.isNotBlank()) { "email must not be blank" }
+        val customer = Customer(
+            id = newId(),
+            fullName = fullName,
+            email = email,
+            phone = phone,
+            address = address,
+        )
+        return repo.create(customer)
+    }
+
+    fun get(id: String): Customer =
+        repo.findById(id) ?: throw NotFoundException("customer $id not found")
+
+    fun list(offset: Int = 0, limit: Int = 25): List<Customer> = repo.list(offset, limit)
+
+    fun update(id: String, fullName: String?, email: String?, phone: String?, address: String?): Customer {
+        val existing = get(id)
+        val updated = existing.copy(
+            fullName = fullName ?: existing.fullName,
+            email = email ?: existing.email,
+            phone = phone ?: existing.phone,
+            address = address ?: existing.address,
+        )
+        return repo.update(updated)
+    }
+
+    fun delete(id: String) = repo.delete(id)
+}
+
+class BreedService(private val repo: BreedRepository) {
+
+    fun create(name: String, description: String?, originCountry: String, avgLifespanYears: Int): Breed {
+        require(name.isNotBlank()) { "name must not be blank" }
+        require(avgLifespanYears > 0) { "avgLifespanYears must be positive" }
+        return repo.create(Breed(
+            id = newId(),
+            name = name,
+            description = description,
+            originCountry = originCountry,
+            avgLifespanYears = avgLifespanYears,
+        ))
+    }
+
+    fun get(id: String): Breed =
+        repo.findById(id) ?: throw NotFoundException("breed $id not found")
+
+    fun list(): List<Breed> = repo.list()
+}
+
+class ShelterService(private val repo: ShelterRepository) {
+
+    fun create(name: String, address: String, phone: String?, email: String?): Shelter {
+        require(name.isNotBlank()) { "name must not be blank" }
+        return repo.create(Shelter(
+            id = newId(),
+            name = name,
+            address = address,
+            phone = phone,
+            email = email,
+        ))
+    }
+
+    fun get(id: String): Shelter =
+        repo.findById(id) ?: throw NotFoundException("shelter $id not found")
+
+    fun list(): List<Shelter> = repo.list()
+}
+
+class InventoryService(private val repo: InventoryRepository) {
+
+    fun stock(catId: String, available: Int) {
+        require(available >= 0) { "available must be >= 0" }
+        val existing = repo.findByCat(catId) ?: Inventory(catId, 0, 0)
+        repo.upsert(existing.copy(available = available, updatedAt = Instant.now()))
+    }
+
+    fun reserve(catId: String, qty: Int) {
+        require(qty > 0) { "qty must be > 0" }
+        val inv = repo.findByCat(catId) ?: Inventory(catId, 0, 0)
+        require(inv.available >= qty) { "not enough stock: have ${inv.available}, need $qty" }
+        repo.upsert(inv.copy(
+            available = inv.available - qty,
+            reserved = inv.reserved + qty,
+            updatedAt = Instant.now(),
+        ))
+    }
+
+    fun release(catId: String, qty: Int) {
+        require(qty > 0) { "qty must be > 0" }
+        val inv = repo.findByCat(catId) ?: return
+        val newReserved = maxOf(0, inv.reserved - qty)
+        val released = inv.reserved - newReserved
+        repo.upsert(inv.copy(
+            reserved = newReserved,
+            available = inv.available + released,
+            updatedAt = Instant.now(),
+        ))
+    }
+
+    fun fulfil(catId: String, qty: Int) {
+        require(qty > 0) { "qty must be > 0" }
+        val inv = repo.findByCat(catId) ?: return
+        val newReserved = maxOf(0, inv.reserved - qty)
+        repo.upsert(inv.copy(
+            reserved = newReserved,
+            updatedAt = Instant.now(),
+        ))
+    }
+
+    fun get(catId: String): Inventory =
+        repo.findByCat(catId) ?: Inventory(catId, 0, 0)
+}
+
+class CatService(
+    private val repo: CatRepository,
+    private val breedRepo: BreedRepository,
+    private val shelterRepo: ShelterRepository,
+    private val inventoryService: InventoryService,
+) {
+
+    fun create(
+        name: String,
+        breedId: String,
+        shelterId: String,
+        birthDate: java.time.LocalDate,
+        priceCents: Long,
+        currency: String,
+        description: String?,
+    ): Cat {
+        require(name.isNotBlank()) { "name must not be blank" }
+        require(priceCents > 0) { "priceCents must be > 0" }
+        require(breedRepo.findById(breedId) != null) { "breed $breedId not found" }
+        require(shelterRepo.findById(shelterId) != null) { "shelter $shelterId not found" }
+        val cat = Cat(
+            id = newId(),
+            name = name,
+            breedId = breedId,
+            shelterId = shelterId,
+            birthDate = birthDate,
+            priceCents = priceCents,
+            currency = currency,
+            description = description,
+        )
+        val created = repo.create(cat)
+        inventoryService.stock(created.id, 1)
+        return created
+    }
+
+    fun get(id: String): Cat =
+        repo.findById(id) ?: throw NotFoundException("cat $id not found")
+
+    fun list(offset: Int = 0, limit: Int = 25): List<Cat> = repo.list(offset, limit)
+
+    fun search(query: String, limit: Int = 25): List<Cat> = repo.searchByName(query, limit)
+
+    fun markAdopted(id: String) = repo.updateStatus(id, CatStatus.ADOPTED)
+
+    fun markRetired(id: String) = repo.updateStatus(id, CatStatus.RETIRED)
+
+    fun delete(id: String) = repo.delete(id)
+}
+
+class CartService(
+    private val cartRepo: CartRepository,
+    private val cartItemRepo: CartItemRepository,
+    private val inventoryService: InventoryService,
+) {
+
+    fun create(customerId: String): Cart {
+        return cartRepo.create(Cart(
+            id = newId(),
+            customerId = customerId,
+        ))
+    }
+
+    fun get(id: String): Cart =
+        cartRepo.findById(id) ?: throw NotFoundException("cart $id not found")
+
+    fun addItem(cartId: String, catId: String, quantity: Int): CartItem {
+        require(quantity > 0) { "quantity must be > 0" }
+        val inv = inventoryService.get(catId)
+        require(inv.available >= quantity) { "not enough stock for cat $catId" }
+        return cartItemRepo.create(CartItem(
+            id = newId(),
+            cartId = cartId,
+            catId = catId,
+            quantity = quantity,
+        ))
+    }
+
+    fun removeItem(cartId: String, catId: String) =
+        cartItemRepo.delete(cartId, catId)
+
+    fun items(cartId: String): List<CartItem> =
+        cartItemRepo.findByCart(cartId)
+
+    fun clear(cartId: String) {
+        cartItemRepo.deleteAllByCart(cartId)
+        cartRepo.delete(cartId)
+    }
+}
+
+class AuditService(private val repo: AuditLogRepository) {
+
+    fun record(actor: String, action: String, target: String): AuditLog {
+        return repo.append(AuditLog(
+            id = newId(),
+            actor = actor,
+            action = action,
+            target = target,
+        ))
+    }
+
+    fun recent(limit: Int = 50): List<AuditLog> = repo.list(limit)
+}
+
+class OrderService(
+    private val orderRepo: OrderRepository,
+    private val orderItemRepo: OrderItemRepository,
+    private val catRepo: CatRepository,
+    private val inventoryService: InventoryService,
+    private val auditService: AuditService,
+) {
+
+    fun place(
+        customerId: String,
+        items: List<Pair<String, Int>>,
+        currency: String,
+        shipAddress: String,
+        billAddress: String,
+        notes: String? = null,
+    ): Order {
+        require(items.isNotEmpty()) { "order must have at least one item" }
+        var total = 0L
+        val orderId = newId()
+        val now = Instant.now()
+        for ((catId, qty) in items) {
+            inventoryService.reserve(catId, qty)
+        }
+        for ((catId, qty) in items) {
+            val cat = catRepo.findById(catId) ?: throw NotFoundException("cat $catId not found")
+            require(cat.currency == currency) { "currency mismatch: cat $catId uses ${cat.currency}, order uses $currency" }
+            val pricePerUnit = cat.priceCents
+            orderItemRepo.create(OrderItem(
+                id = newId(),
+                orderId = orderId,
+                catId = catId,
+                quantity = qty,
+                priceCents = pricePerUnit,
+                currency = currency,
+            ))
+            total += pricePerUnit * qty
+        }
+        val order = Order(
+            id = orderId,
+            customerId = customerId,
+            status = OrderStatus.PENDING,
+            totalCents = total,
+            currency = currency,
+            shipAddress = shipAddress,
+            billAddress = billAddress,
+            notes = notes,
+            placedAt = now,
+        )
+        val saved = orderRepo.create(order)
+        auditService.record(customerId, "order.place", orderId)
+        return saved
+    }
+
+    fun markPaid(id: String): Order {
+        val order = get(id)
+        require(order.status == OrderStatus.PENDING) { "order must be PENDING to pay" }
+        return orderRepo.update(order.copy(status = OrderStatus.PAID))
+    }
+
+    fun ship(id: String): Order {
+        val order = get(id)
+        require(order.status == OrderStatus.PAID) { "order must be PAID to ship" }
+        for (item in orderItemRepo.findByOrder(id)) {
+            inventoryService.fulfil(item.catId, item.quantity)
+        }
+        return orderRepo.update(order.copy(
+            status = OrderStatus.SHIPPED,
+            shippedAt = Instant.now(),
+        ))
+    }
+
+    fun cancel(id: String): Order {
+        val order = get(id)
+        require(order.status in listOf(OrderStatus.PENDING, OrderStatus.PAID)) { "order cannot be cancelled in state ${order.status}" }
+        for (item in orderItemRepo.findByOrder(id)) {
+            inventoryService.release(item.catId, item.quantity)
+        }
+        return orderRepo.update(order.copy(
+            status = OrderStatus.CANCELLED,
+            cancelledAt = Instant.now(),
+        ))
+    }
+
+    fun get(id: String): Order =
+        orderRepo.findById(id) ?: throw NotFoundException("order $id not found")
+
+    fun listByCustomer(customerId: String, offset: Int = 0, limit: Int = 25): List<Order> =
+        orderRepo.listByCustomer(customerId, offset, limit)
+
+    fun items(orderId: String): List<OrderItem> =
+        orderItemRepo.findByOrder(orderId)
+}
+
+private fun newId(): String = UUID.randomUUID().toString().replace("-", "")


### PR DESCRIPTION
## Summary

New Kotlin cat-adoption service backed by Snowflake, with 10 data models, JDBC repositories, service-layer business logic, and a full DDL script for the `TEST` database.

## Changes

- **`model/Models.kt`** — 10 data classes: `Customer`, `Breed`, `Shelter`, `Cat`, `Cart`, `CartItem`, `Order`, `OrderItem`, `Inventory`, `AuditLog`
- **`db/Database.kt`** — Snowflake JDBC connection wrapper + ResultSet helpers
- **`repository/Repositories.kt`** — 10 repository classes with full CRUD (parameterized queries, ILIKE search, MERGE upsert for inventory)
- **`service/Services.kt`** — 7 service classes with validation, inventory reserve/release/fulfil, order lifecycle (place → pay → ship / cancel), audit recording
- **`Main.kt`** — end-to-end demo: creates shelters, breeds, cats, customer; searches cats; builds cart; places/pays/ships order; marks cats adopted; prints audit log
- **`README.md`** — full Snowflake DDL script (`TEST.PETSTORE` schema, 10 tables with PKs/FKs/constraints) + run instructions

## Tables

| # | Table | Model |
|---|-------|-------|
| 1 | `customers` | `Customer` |
| 2 | `breeds` | `Breed` |
| 3 | `shelters` | `Shelter` |
| 4 | `cats` | `Cat` |
| 5 | `carts` | `Cart` |
| 6 | `cart_items` | `CartItem` |
| 7 | `orders` | `Order` |
| 8 | `order_items` | `OrderItem` |
| 9 | `inventory` | `Inventory` |
| 10 | `audit_log` | `AuditLog` |

## Test plan

- [ ] Run the Snowflake DDL script from `README.md` against the `TEST` database
- [ ] Set Snowflake env vars and run `Main.kt` to verify end-to-end flow
